### PR TITLE
Update tests. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 ### Changed
 - **BREAKING**: The tests require the cryptosuite type value to be either
   `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, or `ecdsa-sd-2023`.
+- **BREAKING**: The tags required for the test suite have been updated, shifting
+  from `ecdsa-2019` to `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, and/or
+  `ecdsa-sd-2023`.
 
 ### Removed
-- Removed unnecessary `verificationMethod.controller`. The normative statement
-  for that no longer exists in the spec.
+- Removed unnecessary `verificationMethod.controller` test. The normative
+  statement for that no longer exists in the spec.
 
 ## 1.0.0 - 2023-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
-## 2.0.0 - 2023-11-16
+## 2.0.0 - 2023-11-27
 
 ### Added
 - Adds test to check whether `proof.proofPurpose` field matches the verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
+## 2.0.0 - 2023-11-16
+
+### Added
+- Adds test to check if `proof.proofPurpose` field matches the verification
+  relationship expressed by the verification method controller.
+
+### Changed
+- **BREAKING**: The tests require the cryptosuite type value to be either
+  `ecdsa-rdfc-2019`, `ecdsa-jcs-2019` or `ecdsa-sd-2023`.
+
+### Removed
+- Removed unnecessary `verificationMethod.controller`. The normative statement
+  for that no longer exists in the spec.
+
 ## 1.0.0 - 2023-11-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 2.0.0 - 2023-11-16
 
 ### Added
-- Adds test to check if `proof.proofPurpose` field matches the verification
+- Adds test to check whether `proof.proofPurpose` field matches the verification
   relationship expressed by the verification method controller.
 
 ### Changed
 - **BREAKING**: The tests require the cryptosuite type value to be either
-  `ecdsa-rdfc-2019`, `ecdsa-jcs-2019` or `ecdsa-sd-2023`.
+  `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, or `ecdsa-sd-2023`.
 
 ### Removed
 - Removed unnecessary `verificationMethod.controller`. The normative statement

--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ npm test
 
 You will need an issuer and verifier that are compatible with [VC API](https://w3c-ccg.github.io/vc-api/)
 and are capable of handling issuance and verification of Verifiable Credentials
-with `DataIntegrityProof` proof type using the `ecdsa-2019` cryptosuite.
+with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
+`ecdsa-jcs-2019`, or `ecdsa-sd-2023` cryptosuites.
 
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (/credentials/issue) in the `issuers` property.
 - A credential verifier endpoint (/credentials/verify) in the `verifiers` property.
 
-All endpoints will need the tag `ecdsa-2019`.
+All endpoints will need one of the following cryptosuite tags `ecdsa-rdfc-2019`,
+`ecdsa-jcs-2019` and/or `ecdsa-sd-2023` along with the keyType `P-256` or `P-384`
+the implementation supports.
 
 A simplified manifest would look like this:
 
@@ -52,13 +55,23 @@ A simplified manifest would look like this:
     "id": "",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-2019"]
+    "tags": ["ecdsa-rdfc-2019", "P-256"]
+  }, {
+    "id": "",
+    "endpoint": "https://mycompany.example/credentials/issue",
+    "method": "POST",
+    "tags": ["ecdsa-jcs-2019", "P-384"]
+  }, {
+    "id": "",
+    "endpoint": "https://mycompany.example/credentials/issue",
+    "method": "POST",
+    "tags": ["ecdsa-sd-2023", "P-256"]
   }],
   "verifiers": [{
     "id": "",
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
-    "tags": ["ecdsa-2019"]
+    "tags": ["ecdsa-rdfc-2019", "ecdsa-jcs-2019", "ecdsa-sd-2023"]
   }]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ to your implementation manifest.
 - A credential issuer endpoint (/credentials/issue) in the `issuers` property.
 - A credential verifier endpoint (/credentials/verify) in the `verifiers` property.
 
-All endpoints will require one of the following cryptosuite tags `ecdsa-rdfc-2019`,
-`ecdsa-jcs-2019`, and/or `ecdsa-sd-2023` specified along with
-the keyType `P-256` or `P-384` the implementation supports.
+All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, 
+and/or `ecdsa-sd-2023`, along with a keyType of `P-256` or `P-384`.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ to your implementation manifest.
 - A credential issuer endpoint (/credentials/issue) in the `issuers` property.
 - A credential verifier endpoint (/credentials/verify) in the `verifiers` property.
 
-All endpoints will need one of the following cryptosuite tags `ecdsa-rdfc-2019`,
-`ecdsa-jcs-2019` and/or `ecdsa-sd-2023` along with the keyType `P-256` or `P-384`
-the implementation supports.
+All endpoints will require one of the following cryptosuite tags `ecdsa-rdfc-2019`,
+`ecdsa-jcs-2019`, and/or `ecdsa-sd-2023` specified along with
+the keyType `P-256` or `P-384` the implementation supports.
+
+NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 
 A simplified manifest would look like this:
 
@@ -71,7 +73,9 @@ A simplified manifest would look like this:
     "id": "",
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
-    "tags": ["ecdsa-rdfc-2019", "ecdsa-jcs-2019", "ecdsa-sd-2023"]
+    "tags": [
+      "ecdsa-rdfc-2019", "ecdsa-jcs-2019", "ecdsa-sd-2023"
+    ]
   }]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ to your implementation manifest.
 - A credential issuer endpoint (/credentials/issue) in the `issuers` property.
 - A credential verifier endpoint (/credentials/verify) in the `verifiers` property.
 
-All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, 
-and/or `ecdsa-sd-2023`, along with a keyType of `P-256` or `P-384`.
+All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`,
+and/or `ecdsa-sd-2023`, alongside this cryptosuite tag, you must also specify
+the `supportedEcdsaKeyTypes` property parallel to `tags` listing the ECDSA key
+types that your implementation issues or can verify. Currently, the test suite
+supports `P-256` and `P-384` ECDSA key types..
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 
@@ -56,22 +59,26 @@ A simplified manifest would look like this:
     "id": "",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-rdfc-2019", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256", "P-384"]
+    "tags": ["ecdsa-rdfc-2019"]
   }, {
     "id": "",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-jcs-2019", "P-384"]
+    "supportedEcdsaKeyTypes": ["P-256"]
+    "tags": ["ecdsa-jcs-2019"]
   }, {
     "id": "",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-sd-2023", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"]
+    "tags": ["ecdsa-sd-2023"]
   }],
   "verifiers": [{
     "id": "",
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
+    "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": [
       "ecdsa-rdfc-2019", "ecdsa-jcs-2019", "ecdsa-sd-2023"
     ]

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
-- A credential issuer endpoint (/credentials/issue) in the `issuers` property.
-- A credential verifier endpoint (/credentials/verify) in the `verifiers` property.
+- A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
+- A credential verifier endpoint (`/credentials/verify`) in the `verifiers` property.
 
 All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`,
-and/or `ecdsa-sd-2023`, alongside this cryptosuite tag, you must also specify
-the `supportedEcdsaKeyTypes` property parallel to `tags` listing the ECDSA key
-types that your implementation issues or can verify. Currently, the test suite
-supports `P-256` and `P-384` ECDSA key types..
+and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you must also specify
+the `supportedEcdsaKeyTypes` property, parallel to `tags` listing the ECDSA key
+types issuable or verifiable by your implementation. Currently, the test suite
+supports `P-256` and `P-384` ECDSA key types.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -6,7 +6,7 @@
   cryptosuites.
   The technologies explored in this test suite are experimental.
   This document contains the most recent interoperability report for a
-  DataIntegrityProof using the `ecdsa-2019` cryptosuite.
-  This report is auto-generated.
+  DataIntegrityProof using the `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`, or
+  `ecdsa-sd-2023` cryptosuites. This report is auto-generated.
   </p>
 </section>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "klona": "^2.0.6",
     "mocha": "^10.2.0",
     "uuid": "^9.0.0",
+    "varint": "^6.0.0",
     "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@digitalbazaar/mocha-w3c-interop-reporter": "^1.5.0",
     "base58-universal": "^2.0.0",
     "chai": "^4.3.7",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#add-isEcdsaTests",
     "jsonld-document-loader": "^2.0.0",
     "klona": "^2.0.6",
     "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/w3c/vc-di-ecdsa-test-suite#readme",
   "dependencies": {
     "@digitalbazaar/did-method-key": "^5.1.0",
-    "@digitalbazaar/ecdsa-multikey": "^1.1.3",
+    "@digitalbazaar/ecdsa-multikey": "^1.6.0",
     "@digitalbazaar/http-client": "^4.0.0",
     "@digitalbazaar/mocha-w3c-interop-reporter": "^1.5.0",
     "base58-universal": "^2.0.0",
@@ -40,7 +40,7 @@
     "mocha": "^10.2.0",
     "uuid": "^9.0.0",
     "varint": "^6.0.0",
-    "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
+    "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations#update-db-implementations"
   },
   "devDependencies": {
     "eslint": "^8.52.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@digitalbazaar/did-method-key": "^5.1.0",
     "@digitalbazaar/ecdsa-multikey": "^1.1.3",
-    "@digitalbazaar/http-client": "^3.4.1",
+    "@digitalbazaar/http-client": "^4.0.0",
     "@digitalbazaar/mocha-w3c-interop-reporter": "^1.5.0",
     "base58-universal": "^2.0.0",
     "chai": "^4.3.7",
@@ -42,9 +42,9 @@
     "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
   },
   "devDependencies": {
-    "eslint": "^8.43.0",
+    "eslint": "^8.52.0",
     "eslint-config-digitalbazaar": "^5.0.1",
-    "eslint-plugin-jsdoc": "^46.2.6",
-    "eslint-plugin-unicorn": "^47.0.0"
+    "eslint-plugin-jsdoc": "^46.8.2",
+    "eslint-plugin-unicorn": "^48.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@digitalbazaar/did-method-key": "^5.1.0",
     "@digitalbazaar/ecdsa-multikey": "^1.6.0",
     "@digitalbazaar/http-client": "^4.0.0",
-    "@digitalbazaar/mocha-w3c-interop-reporter": "^1.5.0",
+    "@digitalbazaar/mocha-w3c-interop-reporter": "digitalbazaar/mocha-w3c-interop-reporter#update-status-mark-for-pending",
     "base58-universal": "^2.0.0",
     "chai": "^4.3.7",
     "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#add-isEcdsaTests",

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
     "@digitalbazaar/did-method-key": "^5.1.0",
     "@digitalbazaar/ecdsa-multikey": "^1.6.0",
     "@digitalbazaar/http-client": "^4.0.0",
-    "@digitalbazaar/mocha-w3c-interop-reporter": "digitalbazaar/mocha-w3c-interop-reporter#update-status-mark-for-pending",
+    "@digitalbazaar/mocha-w3c-interop-reporter": "^1.6.0",
     "base58-universal": "^2.0.0",
     "chai": "^4.3.7",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#add-isEcdsaTests",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
     "jsonld-document-loader": "^2.0.0",
     "klona": "^2.0.6",
     "mocha": "^10.2.0",
     "uuid": "^9.0.0",
     "varint": "^6.0.0",
-    "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations#update-db-implementations"
+    "vc-test-suite-implementations": "github:w3c/vc-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^8.52.0",

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -68,6 +68,33 @@ describe('ecdsa-2019 (create)', function() {
               'HTTP API compatible verifier.');
             verificationSuccess({credential: issuedVc, verifier});
           });
+        it('The "proof.proofPurpose" field MUST match the verification ' +
+          'relationship expressed by the verification method controller.',
+        async function() {
+          this.test.cell = {columnId: name, rowId: this.test.title};
+          this.test.cell = {columnId: name, rowId: this.test.title};
+          verificationMethodDocuments.should.not.eql([], 'Expected ' +
+            'at least one "verificationMethodDocument".');
+          verificationMethodDocuments.some(
+            verificationMethodDocument =>
+              verificationMethodDocument?.type === 'Multikey'
+          ).should.equal(true, 'Expected at least one proof to have "type" ' +
+              'property value "Multikey".'
+          );
+          const controllerDocuments = [];
+          for(const verificationMethodDocument of verificationMethodDocuments) {
+            const controllerDocument = await documentLoader({
+              url: verificationMethodDocument.controller
+            });
+            controllerDocuments.push(controllerDocument);
+          }
+          proofs.some(
+            proof => controllerDocuments.some(controllerDocument =>
+              controllerDocument.hasOwnProperty(proof.proofPurpose))
+          ).should.equal(true, 'Expected "proof.proofPurpose" field ' +
+            'to match the verification method controller.'
+          );
+        });
         it('Dereferencing "verificationMethod" MUST result in an object ' +
           'containing a type property with "Multikey" value.',
         async function() {

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -57,10 +57,8 @@ describe('ecdsa-2019 (create)', function() {
           const cryptosuite = ['ecdsa-rdfc-2019', 'ecdsa-jcs-2019'];
           proofs.some(
             proof => cryptosuite.includes(proof?.cryptosuite)
-          ).should.equal(
-            true,
-            'Expected at least one proof to have "cryptosuite" property ' +
-            '"ecdsa-rdfc-2019" or "ecdsa-jcs-2019".'
+          ).should.equal(true, 'Expected at least one proof to have ' +
+            '"cryptosuite" property "ecdsa-rdfc-2019" or "ecdsa-jcs-2019".'
           );
         });
         it('The "proof" MUST verify when using a conformant verifier.',
@@ -75,14 +73,12 @@ describe('ecdsa-2019 (create)', function() {
         async function() {
           this.test.cell = {columnId: name, rowId: this.test.title};
           verificationMethodDocuments.should.not.eql([], 'Expected ' +
-            '"verificationMethodDocuments" to not be empty.');
+            'at least one "verificationMethodDocument".');
           verificationMethodDocuments.some(
             verificationMethodDocument =>
               verificationMethodDocument?.type === 'Multikey'
-          ).should.equal(
-            true,
-            'Expected at least one proof to have "type" property value ' +
-              '"Multikey".'
+          ).should.equal(true, 'Expected at least one proof to have "type" ' +
+              'property value "Multikey".'
           );
         });
         it('The "publicKeyMultibase" property of the verification method ' +
@@ -99,11 +95,8 @@ describe('ecdsa-2019 (create)', function() {
                 shouldBeBs58(publicKeyMultibase) &&
                 shouldBeMulticodecEncoded(publicKeyMultibase);
             }
-          ).should.equal(
-            true,
-            'Expected at "publicKeyMultibase" to to be MULTIBASE formatted ' +
-            'and MULTICODEC encoded.'
-          );
+          ).should.equal(true, 'Expected at "publicKeyMultibase" to to be ' +
+            'MULTIBASE formatted and MULTICODEC encoded.');
         });
       });
     }

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -14,7 +14,6 @@ import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './validVc.js';
 
 const tag = 'ecdsa-2019';
-const cryptosuite = 'ecdsa-2019';
 const {match} = endpoints.filterByTag({
   tags: [tag],
   property: 'issuers'
@@ -52,14 +51,16 @@ describe('ecdsa-2019 (create)', function() {
             verificationMethodDocuments.push(verificationMethodDocument);
           }
         });
-        it('The field "cryptosuite" MUST be "ecdsa-2019".', function() {
+        it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019" or ' +
+          '"ecdsa-jcs-2019".', function() {
           this.test.cell = {columnId: name, rowId: this.test.title};
+          const cryptosuite = ['ecdsa-rdfc-2019', 'ecdsa-jcs-2019'];
           proofs.some(
-            proof => proof?.cryptosuite === cryptosuite
+            proof => cryptosuite.includes(proof?.cryptosuite)
           ).should.equal(
             true,
             'Expected at least one proof to have "cryptosuite" property ' +
-            '"ecdsa-2019".'
+            '"ecdsa-rdfc-2019" or "ecdsa-jcs-2019".'
           );
         });
         it('The "proof" MUST verify when using a conformant verifier.',
@@ -83,30 +84,6 @@ describe('ecdsa-2019 (create)', function() {
             'Expected at least one proof to have "type" property value ' +
               '"Multikey".'
           );
-        });
-        it('The "controller" of the verification method MUST exist and MUST ' +
-          'be a valid URL.', async function() {
-          this.test.cell = {columnId: name, rowId: this.test.title};
-          verificationMethodDocuments.should.not.eql(0, 'Expected ' +
-            '"verificationMethodDocuments" to not be empty.');
-          verificationMethodDocuments.forEach(verificationMethodDocument => {
-            should.exist(verificationMethodDocument, 'Expected dereferencing ' +
-              '"verificationMethod" to return a document.');
-            const {controller} = verificationMethodDocument;
-            should.exist(controller, 'Expected "controller" of the ' +
-              'verification method to exist.');
-            let result;
-            let err;
-            try {
-              result = new URL(controller);
-            } catch(e) {
-              err = e;
-            }
-            should.not.exist(err, 'Expected URL check of the "controller" of ' +
-              'the verification method to not error.');
-            should.exist(result, 'Expected the controller of the ' +
-              'verification method to be a valid URL.');
-          });
         });
         it('The "publicKeyMultibase" property of the verification method ' +
           'MUST be public key encoded according to MULTICODEC and formatted ' +

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -51,14 +51,17 @@ describe('ecdsa-2019 (create)', function() {
             verificationMethodDocuments.push(verificationMethodDocument);
           }
         });
-        it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019" or ' +
-          '"ecdsa-jcs-2019".', function() {
+        it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
+          '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
           this.test.cell = {columnId: name, rowId: this.test.title};
-          const cryptosuite = ['ecdsa-rdfc-2019', 'ecdsa-jcs-2019'];
+          const cryptosuite = [
+            'ecdsa-rdfc-2019', 'ecdsa-jcs-2019', 'ecdsa-sd-2023'
+          ];
           proofs.some(
             proof => cryptosuite.includes(proof?.cryptosuite)
           ).should.equal(true, 'Expected at least one proof to have ' +
-            '"cryptosuite" property "ecdsa-rdfc-2019" or "ecdsa-jcs-2019".'
+            '"cryptosuite" property "ecdsa-rdfc-2019", "ecdsa-jcs-2019" ' +
+            'or "ecdsa-sd-2023".'
           );
         });
         it('The "proof" MUST verify when using a conformant verifier.',

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -75,7 +75,6 @@ describe('ecdsa-2019 (create)', function() {
           'relationship expressed by the verification method controller.',
         async function() {
           this.test.cell = {columnId: name, rowId: this.test.title};
-          this.test.cell = {columnId: name, rowId: this.test.title};
           verificationMethodDocuments.should.not.eql([], 'Expected ' +
             'at least one "verificationMethodDocument".');
           verificationMethodDocuments.some(

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -13,18 +13,18 @@ import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './validVc.js';
 
-const tag = 'ecdsa-2019';
+const tag = 'ecdsa-rdfc-2019';
 const {match} = endpoints.filterByTag({
   tags: [tag],
   property: 'issuers'
 });
 const should = chai.should();
 
-describe('ecdsa-2019 (create)', function() {
+describe('ecdsa-rdfc-2019 (create)', function() {
   checkDataIntegrityProofFormat({
     implemented: match
   });
-  describe('ecdsa-2019 (issuer)', function() {
+  describe('ecdsa-rdfc-2019 (issuer)', function() {
     this.matrix = true;
     this.report = true;
     this.implemented = [...match.keys()];

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -22,33 +22,20 @@ const should = chai.should();
 
 describe('ecdsa-rdfc-2019 (create)', function() {
   checkDataIntegrityProofFormat({
-    implemented: match
+    implemented: match,
+    isEcdsaTests: true
   });
   describe('ecdsa-rdfc-2019 (issuer)', function() {
     this.matrix = true;
     this.report = true;
-    const names = [...match.keys()];
     this.implemented = [];
-    for(const name of names) {
-      const {endpoints} = match.get(name);
-      if(endpoints.length > 1) {
-        for(const endpoint of endpoints) {
-          const {tags} = endpoint.settings;
-          const keyType = getKeyType(tags);
-          this.implemented.push(`${name}: ${keyType}`);
-        }
-      } else {
-        const {tags} = endpoints[0].settings;
-        const keyType = getKeyType(tags);
-        this.implemented.push(`${name}: ${keyType}`);
-      }
-    }
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints, implementation}] of match) {
       for(const endpoint of endpoints) {
-        const tags = endpoint.settings.tags;
-        const keyType = getKeyType(tags);
+        const {supportedEcdsaKeyTypes} = endpoint.settings;
+        const keyType = getKeyType(supportedEcdsaKeyTypes);
+        this.implemented.push(`${name}: ${keyType}`);
         describe(`${name}: ${keyType}`, function() {
           const issuer = endpoint;
           const verifier = implementation.verifiers.find(

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
  */
+import {createInitialVc, getKeyType} from './helpers.js';
 import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
@@ -8,7 +9,6 @@ import chai from 'chai';
 import {
   checkDataIntegrityProofFormat
 } from 'data-integrity-test-suite-assertion';
-import {createInitialVc} from './helpers.js';
 import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './validVc.js';
@@ -31,103 +31,119 @@ describe('ecdsa-rdfc-2019 (create)', function() {
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints, implementation}] of match) {
-      describe(name, function() {
-        const [issuer] = endpoints;
-        const verifier = implementation.verifiers.find(
-          v => v.tags.has(tag));
-        let issuedVc;
-        let proofs;
-        const verificationMethodDocuments = [];
-        before(async function() {
-          issuedVc = await createInitialVc({issuer, vc});
-          proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :
-            [issuedVc?.proof];
-          const verificationMethods = proofs.map(
-            proof => proof.verificationMethod);
-          for(const verificationMethod of verificationMethods) {
-            const verificationMethodDocument = await documentLoader({
-              url: verificationMethod
-            });
-            verificationMethodDocuments.push(verificationMethodDocument);
-          }
-        });
-        it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
-          '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
-          this.test.cell = {columnId: name, rowId: this.test.title};
-          const cryptosuite = [
-            'ecdsa-rdfc-2019', 'ecdsa-jcs-2019', 'ecdsa-sd-2023'
-          ];
-          proofs.some(
-            proof => cryptosuite.includes(proof?.cryptosuite)
-          ).should.equal(true, 'Expected at least one proof to have ' +
-            '"cryptosuite" property "ecdsa-rdfc-2019", "ecdsa-jcs-2019" ' +
-            'or "ecdsa-sd-2023".'
-          );
-        });
-        it('The "proof" MUST verify when using a conformant verifier.',
-          async function() {
-            this.test.cell = {columnId: name, rowId: this.test.title};
-            should.exist(verifier, 'Expected implementation to have a VC ' +
-              'HTTP API compatible verifier.');
-            verificationSuccess({credential: issuedVc, verifier});
-          });
-        it('The "proof.proofPurpose" field MUST match the verification ' +
-          'relationship expressed by the verification method controller.',
-        async function() {
-          this.test.cell = {columnId: name, rowId: this.test.title};
-          verificationMethodDocuments.should.not.eql([], 'Expected ' +
-            'at least one "verificationMethodDocument".');
-          verificationMethodDocuments.some(
-            verificationMethodDocument =>
-              verificationMethodDocument?.type === 'Multikey'
-          ).should.equal(true, 'Expected at least one proof to have "type" ' +
-              'property value "Multikey".'
-          );
-          const controllerDocuments = [];
-          for(const verificationMethodDocument of verificationMethodDocuments) {
-            const controllerDocument = await documentLoader({
-              url: verificationMethodDocument.controller
-            });
-            controllerDocuments.push(controllerDocument);
-          }
-          proofs.some(
-            proof => controllerDocuments.some(controllerDocument =>
-              controllerDocument.hasOwnProperty(proof.proofPurpose))
-          ).should.equal(true, 'Expected "proof.proofPurpose" field ' +
-            'to match the verification method controller.'
-          );
-        });
-        it('Dereferencing "verificationMethod" MUST result in an object ' +
-          'containing a type property with "Multikey" value.',
-        async function() {
-          this.test.cell = {columnId: name, rowId: this.test.title};
-          verificationMethodDocuments.should.not.eql([], 'Expected ' +
-            'at least one "verificationMethodDocument".');
-          verificationMethodDocuments.some(
-            verificationMethodDocument =>
-              verificationMethodDocument?.type === 'Multikey'
-          ).should.equal(true, 'Expected at least one proof to have "type" ' +
-              'property value "Multikey".'
-          );
-        });
-        it('The "publicKeyMultibase" property of the verification method ' +
-          'MUST be public key encoded according to MULTICODEC and formatted ' +
-          'according to MULTIBASE.', async function() {
-          this.test.cell = {columnId: name, rowId: this.test.title};
-          verificationMethodDocuments.should.not.eql([], 'Expected ' +
-            '"verificationMethodDocuments" to not be empty.');
-          verificationMethodDocuments.some(
-            verificationMethodDocument => {
-              const multibase = 'z';
-              const {publicKeyMultibase} = verificationMethodDocument;
-              return publicKeyMultibase.startsWith(multibase) &&
-                shouldBeBs58(publicKeyMultibase) &&
-                shouldBeMulticodecEncoded(publicKeyMultibase);
+      for(const endpoint of endpoints) {
+        const tags = endpoint.settings.tags;
+        const keyType = getKeyType(tags);
+        describe(`${name}: ${keyType}`, function() {
+          const issuer = endpoint;
+          const verifier = implementation.verifiers.find(
+            v => v.tags.has(tag));
+          let issuedVc;
+          let proofs;
+          const verificationMethodDocuments = [];
+          before(async function() {
+            issuedVc = await createInitialVc({issuer, vc});
+            proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :
+              [issuedVc?.proof];
+            const verificationMethods = proofs.map(
+              proof => proof.verificationMethod);
+            for(const verificationMethod of verificationMethods) {
+              const verificationMethodDocument = await documentLoader({
+                url: verificationMethod
+              });
+              verificationMethodDocuments.push(verificationMethodDocument);
             }
-          ).should.equal(true, 'Expected at "publicKeyMultibase" to to be ' +
-            'MULTIBASE formatted and MULTICODEC encoded.');
+          });
+          it.only('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
+            '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
+            this.test.cell = {
+              columnId: `${name}: ${keyType}`, rowId: this.test.title
+            };
+            const cryptosuite = [
+              'ecdsa-rdfc-2019', 'ecdsa-jcs-2019', 'ecdsa-sd-2023'
+            ];
+            proofs.some(
+              proof => cryptosuite.includes(proof?.cryptosuite)
+            ).should.equal(true, 'Expected at least one proof to have ' +
+              '"cryptosuite" property "ecdsa-rdfc-2019", "ecdsa-jcs-2019" ' +
+              'or "ecdsa-sd-2023".'
+            );
+          });
+          it('The "proof" MUST verify when using a conformant verifier.',
+            async function() {
+              this.test.cell = {
+                columnId: `${name}: ${keyType}`, rowId: this.test.title
+              };
+              should.exist(verifier, 'Expected implementation to have a VC ' +
+                'HTTP API compatible verifier.');
+              verificationSuccess({credential: issuedVc, verifier});
+            });
+          it('The "proof.proofPurpose" field MUST match the verification ' +
+            'relationship expressed by the verification method controller.',
+          async function() {
+            this.test.cell = {
+              columnId: `${name}: ${keyType}`, rowId: this.test.title
+            };
+            verificationMethodDocuments.should.not.eql([], 'Expected ' +
+              'at least one "verificationMethodDocument".');
+            verificationMethodDocuments.some(
+              verificationMethodDocument =>
+                verificationMethodDocument?.type === 'Multikey'
+            ).should.equal(true, 'Expected at least one proof to have "type" ' +
+                'property value "Multikey".'
+            );
+            const controllerDocuments = [];
+            for(
+              const verificationMethodDocument of verificationMethodDocuments
+            ) {
+              const controllerDocument = await documentLoader({
+                url: verificationMethodDocument.controller
+              });
+              controllerDocuments.push(controllerDocument);
+            }
+            proofs.some(
+              proof => controllerDocuments.some(controllerDocument =>
+                controllerDocument.hasOwnProperty(proof.proofPurpose))
+            ).should.equal(true, 'Expected "proof.proofPurpose" field ' +
+              'to match the verification method controller.'
+            );
+          });
+          it('Dereferencing "verificationMethod" MUST result in an object ' +
+            'containing a type property with "Multikey" value.',
+          async function() {
+            this.test.cell = {
+              columnId: `${name}: ${keyType}`, rowId: this.test.title
+            };
+            verificationMethodDocuments.should.not.eql([], 'Expected ' +
+              'at least one "verificationMethodDocument".');
+            verificationMethodDocuments.some(
+              verificationMethodDocument =>
+                verificationMethodDocument?.type === 'Multikey'
+            ).should.equal(true, 'Expected at least one proof to have "type" ' +
+                'property value "Multikey".'
+            );
+          });
+          it('The "publicKeyMultibase" property of the verification method ' +
+            'MUST be public key encoded according to MULTICODEC and ' +
+            'formatted according to MULTIBASE.', async function() {
+            this.test.cell = {
+              columnId: `${name}: ${keyType}`, rowId: this.test.title
+            };
+            verificationMethodDocuments.should.not.eql([], 'Expected ' +
+              '"verificationMethodDocuments" to not be empty.');
+            verificationMethodDocuments.some(
+              verificationMethodDocument => {
+                const multibase = 'z';
+                const {publicKeyMultibase} = verificationMethodDocument;
+                return publicKeyMultibase.startsWith(multibase) &&
+                  shouldBeBs58(publicKeyMultibase) &&
+                  shouldBeMulticodecEncoded(publicKeyMultibase);
+              }
+            ).should.equal(true, 'Expected at "publicKeyMultibase" to to be ' +
+              'MULTIBASE formatted and MULTICODEC encoded.');
+          });
         });
-      });
+      }
     }
   });
 });

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -27,7 +27,22 @@ describe('ecdsa-rdfc-2019 (create)', function() {
   describe('ecdsa-rdfc-2019 (issuer)', function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...match.keys()];
+    const names = [...match.keys()];
+    this.implemented = [];
+    for(const name of names) {
+      const {endpoints} = match.get(name);
+      if(endpoints.length > 1) {
+        for(const endpoint of endpoints) {
+          const {tags} = endpoint.settings;
+          const keyType = getKeyType(tags);
+          this.implemented.push(`${name}: ${keyType}`);
+        }
+      } else {
+        const {tags} = endpoints[0].settings;
+        const keyType = getKeyType(tags);
+        this.implemented.push(`${name}: ${keyType}`);
+      }
+    }
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints, implementation}] of match) {
@@ -54,7 +69,7 @@ describe('ecdsa-rdfc-2019 (create)', function() {
               verificationMethodDocuments.push(verificationMethodDocument);
             }
           });
-          it.only('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
+          it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
             '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
             this.test.cell = {
               columnId: `${name}: ${keyType}`, rowId: this.test.title

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
  */
-import {createInitialVc, getKeyType} from './helpers.js';
+import {checkKeyType, createInitialVc} from './helpers.js';
 import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
@@ -34,117 +34,120 @@ describe('ecdsa-rdfc-2019 (create)', function() {
     for(const [name, {endpoints, implementation}] of match) {
       for(const endpoint of endpoints) {
         const {supportedEcdsaKeyTypes} = endpoint.settings;
-        const keyType = getKeyType(supportedEcdsaKeyTypes);
-        this.implemented.push(`${name}: ${keyType}`);
-        describe(`${name}: ${keyType}`, function() {
-          const issuer = endpoint;
-          const verifier = implementation.verifiers.find(
-            v => v.tags.has(tag));
-          let issuedVc;
-          let proofs;
-          const verificationMethodDocuments = [];
-          before(async function() {
-            issuedVc = await createInitialVc({issuer, vc});
-            proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :
-              [issuedVc?.proof];
-            const verificationMethods = proofs.map(
-              proof => proof.verificationMethod);
-            for(const verificationMethod of verificationMethods) {
-              const verificationMethodDocument = await documentLoader({
-                url: verificationMethod
+        for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
+          const keyType = checkKeyType(supportedEcdsaKeyType);
+          this.implemented.push(`${name}: ${keyType}`);
+          describe(`${name}: ${keyType}`, function() {
+            const issuer = endpoint;
+            const verifier = implementation.verifiers.filter(
+              v => v.tags.has(tag) && v.settings.supportedEcdsaKeyTypes
+                .includes(keyType));
+            let issuedVc;
+            let proofs;
+            const verificationMethodDocuments = [];
+            before(async function() {
+              issuedVc = await createInitialVc({issuer, vc});
+              proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :
+                [issuedVc?.proof];
+              const verificationMethods = proofs.map(
+                proof => proof.verificationMethod);
+              for(const verificationMethod of verificationMethods) {
+                const verificationMethodDocument = await documentLoader({
+                  url: verificationMethod
+                });
+                verificationMethodDocuments.push(verificationMethodDocument);
+              }
+            });
+            it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
+              '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
+              this.test.cell = {
+                columnId: `${name}: ${keyType}`, rowId: this.test.title
+              };
+              const cryptosuite = [
+                'ecdsa-rdfc-2019', 'ecdsa-jcs-2019', 'ecdsa-sd-2023'
+              ];
+              proofs.some(
+                proof => cryptosuite.includes(proof?.cryptosuite)
+              ).should.equal(true, 'Expected at least one proof to have ' +
+                '"cryptosuite" property "ecdsa-rdfc-2019", "ecdsa-jcs-2019" ' +
+                'or "ecdsa-sd-2023".'
+              );
+            });
+            it('The "proof" MUST verify when using a conformant verifier.',
+              async function() {
+                this.test.cell = {
+                  columnId: `${name}: ${keyType}`, rowId: this.test.title
+                };
+                should.exist(verifier, 'Expected implementation to have a VC ' +
+                  'HTTP API compatible verifier.');
+                verificationSuccess({credential: issuedVc, verifier});
               });
-              verificationMethodDocuments.push(verificationMethodDocument);
-            }
-          });
-          it('The field "cryptosuite" MUST be "ecdsa-rdfc-2019", ' +
-            '"ecdsa-jcs-2019" or "ecdsa-sd-2023".', function() {
-            this.test.cell = {
-              columnId: `${name}: ${keyType}`, rowId: this.test.title
-            };
-            const cryptosuite = [
-              'ecdsa-rdfc-2019', 'ecdsa-jcs-2019', 'ecdsa-sd-2023'
-            ];
-            proofs.some(
-              proof => cryptosuite.includes(proof?.cryptosuite)
-            ).should.equal(true, 'Expected at least one proof to have ' +
-              '"cryptosuite" property "ecdsa-rdfc-2019", "ecdsa-jcs-2019" ' +
-              'or "ecdsa-sd-2023".'
-            );
-          });
-          it('The "proof" MUST verify when using a conformant verifier.',
+            it('The "proof.proofPurpose" field MUST match the verification ' +
+              'relationship expressed by the verification method controller.',
             async function() {
               this.test.cell = {
                 columnId: `${name}: ${keyType}`, rowId: this.test.title
               };
-              should.exist(verifier, 'Expected implementation to have a VC ' +
-                'HTTP API compatible verifier.');
-              verificationSuccess({credential: issuedVc, verifier});
-            });
-          it('The "proof.proofPurpose" field MUST match the verification ' +
-            'relationship expressed by the verification method controller.',
-          async function() {
-            this.test.cell = {
-              columnId: `${name}: ${keyType}`, rowId: this.test.title
-            };
-            verificationMethodDocuments.should.not.eql([], 'Expected ' +
-              'at least one "verificationMethodDocument".');
-            verificationMethodDocuments.some(
-              verificationMethodDocument =>
-                verificationMethodDocument?.type === 'Multikey'
-            ).should.equal(true, 'Expected at least one proof to have "type" ' +
-                'property value "Multikey".'
-            );
-            const controllerDocuments = [];
-            for(
-              const verificationMethodDocument of verificationMethodDocuments
-            ) {
-              const controllerDocument = await documentLoader({
-                url: verificationMethodDocument.controller
-              });
-              controllerDocuments.push(controllerDocument);
-            }
-            proofs.some(
-              proof => controllerDocuments.some(controllerDocument =>
-                controllerDocument.hasOwnProperty(proof.proofPurpose))
-            ).should.equal(true, 'Expected "proof.proofPurpose" field ' +
-              'to match the verification method controller.'
-            );
-          });
-          it('Dereferencing "verificationMethod" MUST result in an object ' +
-            'containing a type property with "Multikey" value.',
-          async function() {
-            this.test.cell = {
-              columnId: `${name}: ${keyType}`, rowId: this.test.title
-            };
-            verificationMethodDocuments.should.not.eql([], 'Expected ' +
-              'at least one "verificationMethodDocument".');
-            verificationMethodDocuments.some(
-              verificationMethodDocument =>
-                verificationMethodDocument?.type === 'Multikey'
-            ).should.equal(true, 'Expected at least one proof to have "type" ' +
-                'property value "Multikey".'
-            );
-          });
-          it('The "publicKeyMultibase" property of the verification method ' +
-            'MUST be public key encoded according to MULTICODEC and ' +
-            'formatted according to MULTIBASE.', async function() {
-            this.test.cell = {
-              columnId: `${name}: ${keyType}`, rowId: this.test.title
-            };
-            verificationMethodDocuments.should.not.eql([], 'Expected ' +
-              '"verificationMethodDocuments" to not be empty.');
-            verificationMethodDocuments.some(
-              verificationMethodDocument => {
-                const multibase = 'z';
-                const {publicKeyMultibase} = verificationMethodDocument;
-                return publicKeyMultibase.startsWith(multibase) &&
-                  shouldBeBs58(publicKeyMultibase) &&
-                  shouldBeMulticodecEncoded(publicKeyMultibase);
+              verificationMethodDocuments.should.not.eql([], 'Expected ' +
+                'at least one "verificationMethodDocument".');
+              verificationMethodDocuments.some(
+                verificationMethodDocument =>
+                  verificationMethodDocument?.type === 'Multikey'
+              ).should.equal(true, 'Expected at least one proof to have ' +
+                '"type" property value "Multikey".'
+              );
+              const controllerDocuments = [];
+              for(
+                const verificationMethodDocument of verificationMethodDocuments
+              ) {
+                const controllerDocument = await documentLoader({
+                  url: verificationMethodDocument.controller
+                });
+                controllerDocuments.push(controllerDocument);
               }
-            ).should.equal(true, 'Expected at "publicKeyMultibase" to to be ' +
-              'MULTIBASE formatted and MULTICODEC encoded.');
+              proofs.some(
+                proof => controllerDocuments.some(controllerDocument =>
+                  controllerDocument.hasOwnProperty(proof.proofPurpose))
+              ).should.equal(true, 'Expected "proof.proofPurpose" field ' +
+                'to match the verification method controller.'
+              );
+            });
+            it('Dereferencing "verificationMethod" MUST result in an object ' +
+              'containing a type property with "Multikey" value.',
+            async function() {
+              this.test.cell = {
+                columnId: `${name}: ${keyType}`, rowId: this.test.title
+              };
+              verificationMethodDocuments.should.not.eql([], 'Expected ' +
+                'at least one "verificationMethodDocument".');
+              verificationMethodDocuments.some(
+                verificationMethodDocument =>
+                  verificationMethodDocument?.type === 'Multikey'
+              ).should.equal(true, 'Expected at least one proof to have ' +
+                '"type" property value "Multikey".'
+              );
+            });
+            it('The "publicKeyMultibase" property of the verification method ' +
+              'MUST be public key encoded according to MULTICODEC and ' +
+              'formatted according to MULTIBASE.', async function() {
+              this.test.cell = {
+                columnId: `${name}: ${keyType}`, rowId: this.test.title
+              };
+              verificationMethodDocuments.should.not.eql([], 'Expected ' +
+                '"verificationMethodDocuments" to not be empty.');
+              verificationMethodDocuments.some(
+                verificationMethodDocument => {
+                  const multibase = 'z';
+                  const {publicKeyMultibase} = verificationMethodDocument;
+                  return publicKeyMultibase.startsWith(multibase) &&
+                    shouldBeBs58(publicKeyMultibase) &&
+                    shouldBeMulticodecEncoded(publicKeyMultibase);
+                }
+              ).should.equal(true, 'Expected at "publicKeyMultibase" to ' +
+                'be MULTIBASE formatted and MULTICODEC encoded.');
+            });
           });
-        });
+        }
       }
     }
   });

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -10,14 +10,14 @@ import {endpoints} from 'vc-test-suite-implementations';
 import {klona} from 'klona';
 import {validVc as vc} from './validVc.js';
 
-const tag = 'ecdsa-2019';
-// only use implementations with `ecdsa-2019` verifiers.
+const tag = 'ecdsa-rdfc-2019';
+// only use implementations with `ecdsa-rdfc-2019` verifiers.
 const {match} = endpoints.filterByTag({
   tags: [tag],
   property: 'verifiers'
 });
 
-describe('ecdsa-2019 (verify)', function() {
+describe('ecdsa-rdfc-2019 (verify)', function() {
   let credential;
   beforeEach(async function() {
     const {match} = endpoints.filterByTag({
@@ -32,7 +32,7 @@ describe('ecdsa-2019 (verify)', function() {
   checkDataIntegrityProofVerifyErrors({
     implemented: match
   });
-  describe('ecdsa-2019 cryptosuite (verifier)', function() {
+  describe('ecdsa-rdfc-2019 cryptosuite (verifier)', function() {
     // this will tell the report
     // to make an interop matrix with this suite
     this.matrix = true;
@@ -45,7 +45,7 @@ describe('ecdsa-2019 (verify)', function() {
       describe(columnId, function() {
         // wrap the testApi config in an Implementation class
         const [verifier] = endpoints;
-        it('MUST verify a valid VC with an ecdsa-2019 proof',
+        it('MUST verify a valid VC with an ecdsa-rdfc-2019 proof',
           async function() {
             this.test.cell = {columnId, rowId: this.test.title};
             await verificationSuccess({credential, verifier});

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -17,7 +17,7 @@ const {match} = endpoints.filterByTag({
   property: 'verifiers'
 });
 
-describe('ecdsa-rdfc-2019 (verify)', function() {
+describe.skip('ecdsa-rdfc-2019 (verify)', function() {
   let credential;
   beforeEach(async function() {
     const {match} = endpoints.filterByTag({

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -50,9 +50,8 @@ describe('ecdsa-2019 (verify)', function() {
             this.test.cell = {columnId, rowId: this.test.title};
             await verificationSuccess({credential, verifier});
           });
-        it('If the "cryptosuite" field is not the string "ecdsa-2019", ' +
-          'an error MUST be raised.',
-        async function() {
+        it('If the "cryptosuite" field is not the string "ecdsa-rdfc-2019" ' +
+          'or "ecdsa-jcs-2019", an error MUST be raised.', async function() {
           this.test.cell = {columnId, rowId: this.test.title};
           credential.proof.cryptosuite = 'not-ecdsa-2019';
           await verificationFail({credential, verifier});

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -51,7 +51,8 @@ describe('ecdsa-2019 (verify)', function() {
             await verificationSuccess({credential, verifier});
           });
         it('If the "cryptosuite" field is not the string "ecdsa-rdfc-2019" ' +
-          'or "ecdsa-jcs-2019", an error MUST be raised.', async function() {
+          '"ecdsa-jcs-2019" or ""ecdsa-sd-2023", an error MUST be raised.',
+        async function() {
           this.test.cell = {columnId, rowId: this.test.title};
           credential.proof.cryptosuite = 'invalid-cryptosuite';
           await verificationFail({credential, verifier});

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -51,7 +51,7 @@ describe('ecdsa-2019 (verify)', function() {
             await verificationSuccess({credential, verifier});
           });
         it('If the "cryptosuite" field is not the string "ecdsa-rdfc-2019" ' +
-          '"ecdsa-jcs-2019" or ""ecdsa-sd-2023", an error MUST be raised.',
+          '"ecdsa-jcs-2019" or "ecdsa-sd-2023", an error MUST be raised.',
         async function() {
           this.test.cell = {columnId, rowId: this.test.title};
           credential.proof.cryptosuite = 'invalid-cryptosuite';

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -53,7 +53,7 @@ describe('ecdsa-2019 (verify)', function() {
         it('If the "cryptosuite" field is not the string "ecdsa-rdfc-2019" ' +
           'or "ecdsa-jcs-2019", an error MUST be raised.', async function() {
           this.test.cell = {columnId, rowId: this.test.title};
-          credential.proof.cryptosuite = 'not-ecdsa-2019';
+          credential.proof.cryptosuite = 'invalid-cryptosuite';
           await verificationFail({credential, verifier});
         });
       });

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -17,7 +17,7 @@ const {
   match: verifierMatches
 } = endpoints.filterByTag({tags: [tag], property: 'verifiers'});
 
-describe('ecdsa-rdfc-2019 (interop)', function() {
+describe.skip('ecdsa-rdfc-2019 (interop)', function() {
   // this will tell the report
   // to make an interop matrix with this suite
   this.matrix = true;

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -17,37 +17,86 @@ const {
   match: verifierMatches
 } = endpoints.filterByTag({tags: [tag], property: 'verifiers'});
 
-describe.skip('ecdsa-rdfc-2019 (interop)', function() {
+describe('ecdsa-rdfc-2019 (interop)', function() {
   // this will tell the report
   // to make an interop matrix with this suite
   this.matrix = true;
   this.report = true;
-  this.implemented = [...verifierMatches.keys()];
+  this.implemented = [];
   this.rowLabel = 'Issuer';
   this.columnLabel = 'Verifier';
+
+  const issuers = [];
   for(const [issuerName, {endpoints}] of issuerMatches) {
-    let issuedVc;
-    before(async function() {
-      const [issuer] = endpoints;
-      issuedVc = await createInitialVc({issuer, vc});
-    });
-    for(const [verifierName, {endpoints}] of verifierMatches) {
-      const [verifier] = endpoints;
-      it(`${verifierName} should verify ${issuerName}`, async function() {
-        this.test.cell = {rowId: issuerName, columnId: verifierName};
-        const body = {
-          verifiableCredential: issuedVc,
-          options: {
-            checks: ['proof']
-          }
-        };
-        const {result, error} = await verifier.post({json: body});
-        should.not.exist(error, 'Expected verifier to not error.');
-        should.exist(result, 'Expected result from verifier.');
-        should.exist(result.status, 'Expected verifier to return an HTTP' +
-          'status code');
-        result.status.should.equal(200, 'Expected HTTP status code to be 200.');
+    for(const issuerEndpoint of endpoints) {
+      const {supportedEcdsaKeyTypes} = issuerEndpoint.settings;
+      const issuerDisplayName =
+        `${issuerName}: ${supportedEcdsaKeyTypes.join(', ')}`;
+      for(const issuerSupportedEcdsaKeyType of supportedEcdsaKeyTypes) {
+        issuers.push({
+          issuerDisplayName,
+          issuerSupportedEcdsaKeyType,
+          issuerEndpoint
+        });
+      }
+    }
+  }
+
+  const verifiers = [];
+  for(const [verifierName, {endpoints}] of verifierMatches) {
+    for(const verifierEndpoint of endpoints) {
+      const {supportedEcdsaKeyTypes} = verifierEndpoint.settings;
+      const verifierDisplayName =
+        `${verifierName}: ${supportedEcdsaKeyTypes.join(', ')}`;
+      verifiers.push({
+        verifierDisplayName,
+        verifierSupportedEcdsaKeyTypes: supportedEcdsaKeyTypes,
+        verifierEndpoint
       });
+      // add verifiers' names for reporting
+      this.implemented.push(verifierDisplayName);
+    }
+  }
+
+  for(const {
+    issuerDisplayName, issuerSupportedEcdsaKeyType, issuerEndpoint
+  } of issuers) {
+    for(const {
+      verifierDisplayName, verifierSupportedEcdsaKeyTypes, verifierEndpoint
+    } of verifiers) {
+      if(
+        !verifierSupportedEcdsaKeyTypes.includes(issuerSupportedEcdsaKeyType)
+      ) {
+        // If the issuer keyType is not supported by the verifier
+        // we skip that case
+        continue;
+      }
+      let issuedVc;
+      before(async function() {
+        issuedVc = await createInitialVc({issuer: issuerEndpoint, vc});
+      });
+      it(`'${verifierDisplayName}' should verify '${issuerDisplayName}'`,
+        async function() {
+          this.test.cell = {
+            rowId: issuerDisplayName,
+            columnId: verifierDisplayName
+          };
+
+          const body = {
+            verifiableCredential: issuedVc,
+            options: {
+              checks: ['proof']
+            }
+          };
+
+          const {result, error} = await verifierEndpoint.post({json: body});
+          should.not.exist(error, 'Expected verifier to not error.');
+          should.exist(result, 'Expected result from verifier.');
+          should.exist(result.status, 'Expected verifier to return an HTTP' +
+            'status code');
+          result.status.should.equal(
+            200, 'Expected HTTP status code to be 200.');
+        });
     }
   }
 });

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -7,9 +7,9 @@ import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './validVc.js';
 
 const should = chai.should();
-const tag = 'ecdsa-2019';
+const tag = 'ecdsa-rdfc-2019';
 
-// only use implementations with `ecdsa-2019` issuers.
+// only use implementations with `ecdsa-rdfc-2019` issuers.
 const {
   match: issuerMatches
 } = endpoints.filterByTag({tags: [tag], property: 'issuers'});
@@ -17,7 +17,7 @@ const {
   match: verifierMatches
 } = endpoints.filterByTag({tags: [tag], property: 'verifiers'});
 
-describe('ecdsa-2019 (interop)', function() {
+describe('ecdsa-rdfc-2019 (interop)', function() {
   // this will tell the report
   // to make an interop matrix with this suite
   this.matrix = true;

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -2,11 +2,11 @@
  * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
  */
 import {
-  expectedP256Prefix, expectedP384Prefix, multibaseMultikeyHeaderP256,
-  multibaseMultikeyHeaderP384,
+  multibaseMultikeyHeaderP256, multibaseMultikeyHeaderP384,
 } from './helpers.js';
 import chai from 'chai';
 import {decode} from 'base58-universal';
+import varint from 'varint';
 
 const should = chai.should();
 
@@ -34,6 +34,7 @@ export const shouldBeMulticodecEncoded = async s => {
     const prefix = Array.from(bytes.slice(0, 2));
     // the multicodec encoding of a P-256 public key is the two-byte
     // prefix 0x1200 followed by the 33-byte compressed public key data.
+    const expectedP256Prefix = await varint.encode(0x1200);
     return JSON.stringify(prefix) === JSON.stringify(expectedP256Prefix);
   }
 
@@ -44,6 +45,7 @@ export const shouldBeMulticodecEncoded = async s => {
     const prefix = Array.from(bytes.slice(0, 2));
     // the multicodec encoding of a P-384 public key is the two-byte prefix
     // 0x1201 followed by the 49-byte compressed public key data.
+    const expectedP384Prefix = await varint.encode(0x1201);
     return JSON.stringify(prefix) === JSON.stringify(expectedP384Prefix);
   }
   // Unsupported key type, return false

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -33,12 +33,10 @@ export const multibaseMultikeyHeaderP256 =
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
 
-export function getKeyType(supportedEcdsaKeyTypes) {
+export function checkKeyType(keyType) {
   const supportedKeyTypes = ['P-256', 'P-384'];
-  for(const keyType of supportedKeyTypes) {
-    if(supportedEcdsaKeyTypes.includes(keyType)) {
-      return keyType;
-    }
+  if(supportedKeyTypes.includes(keyType)) {
+    return keyType;
   }
-  return null;
+  throw new Error(`Unsupported ECDSA key type: ${keyType}.`);
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -32,7 +32,3 @@ export const multibaseMultikeyHeaderP256 =
 
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
-
-export const expectedP256Prefix = [128, 36];
-
-export const expectedP384Prefix = [129, 36];

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -33,10 +33,10 @@ export const multibaseMultikeyHeaderP256 =
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
 
-export function getKeyType(tags) {
+export function getKeyType(supportedEcdsaKeyTypes) {
   const supportedKeyTypes = ['P-256', 'P-384'];
   for(const keyType of supportedKeyTypes) {
-    if(tags.includes(keyType)) {
+    if(supportedEcdsaKeyTypes.includes(keyType)) {
       return keyType;
     }
   }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -32,3 +32,13 @@ export const multibaseMultikeyHeaderP256 =
 
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
+
+export function getKeyType(tags) {
+  const supportedKeyTypes = ['P-256', 'P-384'];
+  for(const keyType of supportedKeyTypes) {
+    if(tags.includes(keyType)) {
+      return keyType;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
- Updated test for verifying cryptosuite value.
   - `proof.cryptosuite` should either be `ecdsa-rdfc-2019` or `ecdsa-jcs-2019` as per the latest `Data Integrity ECDSA Cryptosuites v1.0` spec
- Removed unnecessary `verificationMethod controller` test. The normative statement for that no longer exists in the spec.
- Added test to check if `proof.purpose` field matches the verification method controller. 
```
Tests passed 131/141 92%
Tests failed 10/141 8%
Failures 10
Tests skipped 0
Total tests 141
```