### PR TITLE
Get issuer and vc holder used in test data generation from test  config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.json
 reports/**
 !.gitkeep
 credentials/*.json
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ reports/**
 !.gitkeep
 credentials/*.json
 .vscode
+.localImplementationsConfig.cjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
+## 2.2.0 - 2023-12-21
+
+### Changed
+- Get issuer and vc holder used in test data generation from test
+  config. This will allow testers to specify the issuer and/or vc holder for generating the test data. The default value has been set to `Digital Bazaar`.
+
 ## 2.1.0 - 2023-11-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 2.2.0 - 2024-01-03
 
 ### Changed
-- Get issuer and vc holder used in test data generation from test
-  config. This will allow testers to specify the issuer and/or vc holder for
+- Get issuer and VC holder used in test data generation from test
+  config. This will allow testers to specify the issuer and/or VC holder for
   generating the test data. The default values have been set to
   `Digital Bazaar`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
-## 2.2.0 - 2023-12-21
+## 2.2.0 - 2024-01-03
 
 ### Changed
 - Get issuer and vc holder used in test data generation from test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 2.2.0 - 2024-01-03
 
 ### Changed
-- Get issuer and VC holder used in test data generation from test
-  config. This will allow testers to specify the issuer and/or VC holder for
+- Get VC issuer and holder from test config for use in test data generation.
+  This will allow testers to specify the VC issuer and/or holder for
   generating the test data. The default values have been set to
   `Digital Bazaar`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Changed
 - Get issuer and vc holder used in test data generation from test
-  config. This will allow testers to specify the issuer and/or vc holder for generating the test data. The default value has been set to `Digital Bazaar`.
+  config. This will allow testers to specify the issuer and/or vc holder for
+  generating the test data. The default values have been set to
+  `Digital Bazaar`.
 
 ## 2.1.0 - 2023-11-29
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,15 @@ npm i
 
 ## Usage
 
+To generate test data used in the test suite, testers are required to specify
+the issuer name using the environment variable `ISSUER_NAME`.
+
+Additionally, vc holder name may also be specified for generating disclosed
+test credentials for ecdsa sd tests using the environment variable
+`HOLDER_NAME`. If it is not specified, `Digital Bazaar` vc holder will be used.
+
 ```
-npm test
+ISSUER_NAME="IssuerName" HOLDER_NAME="HolderName" npm test
 ```
 
 ## Implementation
@@ -39,13 +46,14 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
-- A credential verifier endpoint (`/credentials/verify`) in the `verifiers` property.
+- A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
+property.
 
-All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`, `ecdsa-jcs-2019`,
-and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you must also specify
-the `supportedEcdsaKeyTypes` property, parallel to `tags` listing the ECDSA key
-types issuable or verifiable by your implementation. Currently, the test suite
-supports `P-256` and `P-384` ECDSA key types.
+All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
+`ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you
+must also specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
+listing the ECDSA key types issuable or verifiable by your implementation.
+Currently, the test suite supports `P-256` and `P-384` ECDSA key types.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 
@@ -91,8 +99,8 @@ OAuth2 authentication to your endpoints. You can find an example in the
 [vc-test-suite-implementations README](https://github.com/w3c/vc-test-suite-implementations#adding-a-new-implementation).
 
 To run the tests, some implementations may require client secrets that can be
-passed as environment variables to the test script. To see which implementations require client
-secrets, please check the implementation manifest within the
+passed as environment variables to the test script. To see which implementations
+require client secrets, please check the implementation manifest within the
 [vc-test-suite-implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main/implementations) library.
 
 ### Docker Integration (TODO)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ npm i
 To generate test data used in the test suite, testers are required to specify
 the issuer name using the environment variable `ISSUER_NAME`.
 
-Additionally, vc holder name may also be specified for generating disclosed
-test credentials for ecdsa sd tests using the environment variable
-`HOLDER_NAME`. If it is not specified, `Digital Bazaar` vc holder will be used.
+In addition, VC holder name for generating disclosed test credentials for
+ECDSA-SD tests may be specified using the environment variable `HOLDER_NAME`.
+If `$HOLDER_NAME` is not specified, `Digital Bazaar` will be used.
 
 ```
 ISSUER_NAME="IssuerName" HOLDER_NAME="HolderName" npm test

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ npm i
 To generate test data used in the test suite, testers are required to specify
 the issuer name using the environment variable `ISSUER_NAME`.
 
-In addition, VC holder name for generating disclosed test credentials for
-ECDSA-SD tests may be specified using the environment variable `HOLDER_NAME`.
+In addition, the environment variable `HOLDER_NAME` may be used to specify
+the VC holder name for generating disclosed test credentials for ECDSA-SD tests.
 If `$HOLDER_NAME` is not specified, `Digital Bazaar` will be used.
 
 ```

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -7,6 +7,7 @@ import {
 } from 'data-integrity-test-suite-assertion';
 import {createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';
+import {issuerName} from './test-config.js';
 import {validVc as vc} from './mock-data.js';
 
 const tag = 'ecdsa-rdfc-2019';
@@ -29,8 +30,9 @@ describe('ecdsa-rdfc-2019 (verify)', function() {
         tags: [tag],
         property: 'issuers'
       });
-      // Use DB issuer to issue a verifiable credential for the verifier tests
-      issuers = match.get('Digital Bazaar').endpoints;
+      // Uses DB issuer as default issuer to issue a verifiable credential for
+      // the verifier tests.
+      issuers = match.get(issuerName).endpoints;
     });
     // this will tell the report
     // to make an interop matrix with this suite

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -30,8 +30,8 @@ describe('ecdsa-rdfc-2019 (verify)', function() {
         tags: [tag],
         property: 'issuers'
       });
-      // Uses DB issuer as default issuer to issue a verifiable credential for
-      // the verifier tests.
+      // Uses 'Digital Bazaar' as default issuer to issue a verifiable
+      // credential for the verifier tests.
       issuers = match.get(issuerName).endpoints;
     });
     // this will tell the report

--- a/tests/50-sd-verify.js
+++ b/tests/50-sd-verify.js
@@ -4,6 +4,7 @@
 import {achievementCredential, dlCredentialNoIds, validVc as vc} from
   './mock-data.js';
 import {createDisclosedVc, createInitialVc} from './helpers.js';
+import {holderName, issuerName} from './test-config.js';
 import {verificationFail, verificationSuccess} from './assertions.js';
 import {
   checkDataIntegrityProofVerifyErrors
@@ -36,9 +37,10 @@ describe('ecdsa-sd-2023 (verify)', function() {
         tags: ['vcHolder'],
         property: 'vcHolders'
       });
-      // Use DB issuer to issue a verifiable credential for the verifier tests
-      issuers = matchingIssuers.get('Digital Bazaar').endpoints;
-      const vcHolders = matchingVcHolders.get('Digital Bazaar').endpoints;
+      // Uses DB issuer as default issuer to issue a verifiable credential for
+      // the verifier tests.
+      issuers = matchingIssuers.get(issuerName).endpoints;
+      const vcHolders = matchingVcHolders.get(holderName).endpoints;
       vcHolder = vcHolders[0];
     });
     // this will tell the report

--- a/tests/50-sd-verify.js
+++ b/tests/50-sd-verify.js
@@ -37,8 +37,8 @@ describe('ecdsa-sd-2023 (verify)', function() {
         tags: ['vcHolder'],
         property: 'vcHolders'
       });
-      // Uses DB issuer as default issuer to issue a verifiable credential for
-      // the verifier tests.
+      // Uses 'Digital Bazaar' as default issuer to issue a verifiable
+      // credential for the verifier tests.
       issuers = matchingIssuers.get(issuerName).endpoints;
       const vcHolders = matchingVcHolders.get(holderName).endpoints;
       vcHolder = vcHolders[0];

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -3,6 +3,7 @@
  */
 import {createDisclosedVc, createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';
+import {holderName} from './test-config.js';
 import {validVc as vc} from './mock-data.js';
 import {verificationSuccess} from './assertions.js';
 
@@ -77,8 +78,9 @@ describe('ecdsa-sd-2023 (interop)', function() {
           tags: ['vcHolder'],
           property: 'vcHolders'
         });
-        // Use DB vc holder to create disclosed credentials
-        const vcHolders = matchingVcHolders.get('Digital Bazaar').endpoints;
+        // Uses DB vc holder as default to create disclosed credentials for
+        // the tests.
+        const vcHolders = matchingVcHolders.get(holderName).endpoints;
         const vcHolder = vcHolders[0];
         ({disclosedCredential} = await createDisclosedVc({
           selectivePointers: ['/credentialSubject/id'],

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -78,8 +78,8 @@ describe('ecdsa-sd-2023 (interop)', function() {
           tags: ['vcHolder'],
           property: 'vcHolders'
         });
-        // Uses DB vc holder as default to create disclosed credentials for
-        // the tests.
+        // Uses 'Digital Bazaar' as default VC holder to create disclosed
+        // credentials for the tests.
         const vcHolders = matchingVcHolders.get(holderName).endpoints;
         const vcHolder = vcHolders[0];
         ({disclosedCredential} = await createDisclosedVc({

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -1,0 +1,5 @@
+/*!
+ * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ */
+export const issuerName = process.env.ISSUER_NAME || 'Digital Bazaar';
+export const holderName = process.env.HOLDER_NAME || 'Digital Bazaar';


### PR DESCRIPTION
This will allow testers to specify the issuer and/or vc holder for generating the test data.