### PR TITLE
Fix license info.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,7 @@
+// Copyright 2023 Digital Bazaar, Inc.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 module.exports = {
   env: {
     node: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,7 @@
+# Copyright 2023 Digital Bazaar, Inc.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 name: Generate Interop Report
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Copyright 2023 Digital Bazaar, Inc.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 *.sw[nop]
 *.py[co]
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ TAGS
 config.json
 node_modules/
 package-lock.json
+package-lock.json.license
 *.vswp
 config.json
 reports/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
 ## 2.1.0 - 2023-11-29

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, W3C Verifiable Credentials Working Group Contributors 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, W3C Verifiable Credentials Working Group Contributors 
+Copyright (c) 2023-2024, World Wide Web Consortium
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
 # [ECDSA](https://www.w3.org/TR/vc-di-ecdsa/) Cryptosuite test suite
 
 ## Table of Contents

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -1,3 +1,9 @@
+{{!--
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+--}}
+
 <section id="abstract">
   <p>
   The purpose of this test suite is to demonstrate a path to interoperability

--- a/package.json
+++ b/package.json
@@ -11,11 +11,17 @@
     "test": "mocha tests/ --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options abstract=\"$PWD/abstract.hbs\",reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"Data Integrity ecdsa 2019 Interoperability Report 1.0\" --timeout 15000 --preserve-symlinks",
     "lint": "eslint ."
   },
+  "license": "BSD-3-Clause",
   "author": {
-    "name": "W3C Verifiable Credentials Working Group",
+    "name": "W3C Verifiable Credentials Working Group Contributors",
     "email": "public-vc-wg@w3.org",
     "url": "https://www.w3.org/groups/wg/vc/"
   },
+  "contributors": [{
+    "name": "Digital Bazaar, Inc.",
+    "email": "support@digitalbazaar.com",
+    "url": "https://digitalbazaar.com/"
+  }],
   "engines": {
     "node": ">=18"
   },

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/respecConfig.json.license
+++ b/respecConfig.json.license
@@ -1,0 +1,3 @@
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/.eslintrc.cjs
+++ b/tests/.eslintrc.cjs
@@ -1,3 +1,7 @@
+// Copyright 2023 Digital Bazaar, Inc.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 module.exports = {
   env: {
     mocha: true

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {checkKeyType, createInitialVc} from './helpers.js';
 import {

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {verificationFail, verificationSuccess} from './assertions.js';
 import {

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {checkKeyType, createInitialVc} from './helpers.js';
 import {

--- a/tests/50-sd-verify.js
+++ b/tests/50-sd-verify.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {achievementCredential, dlCredentialNoIds, validVc as vc} from
   './mock-data.js';

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {createDisclosedVc, createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {
   multibaseMultikeyHeaderP256, multibaseMultikeyHeaderP384,

--- a/tests/didResolver.js
+++ b/tests/didResolver.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import * as didMethodKey from '@digitalbazaar/did-method-key';
 import * as EcdsaMultikey from '@digitalbazaar/ecdsa-multikey';

--- a/tests/documentLoader.js
+++ b/tests/documentLoader.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {didResolver} from './didResolver.js';
 import {httpClient} from '@digitalbazaar/http-client';

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 import {klona} from 'klona';
 import {v4 as uuidv4} from 'uuid';

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -1,5 +1,6 @@
 /*!
- * Copyright 2023 Digital Bazaar, Inc. All Rights Reserved
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 export const validVc = {
   '@context': [

--- a/w3c.json.license
+++ b/w3c.json.license
@@ -1,0 +1,3 @@
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
This may be a bit farther than we want to go...but it is thorough!

The changes here acheive full complaince with https://reuse.software/
from Free Software Foundation Europe. It should also result in better
and more accurate per-file license metadata in systems like
https://clearlydefined.io/

We don't have to merge all of this, but I wanted to post it on this
simple repo to gather feedback on the approach.
