### PR TITLE
Throw in interop if no vc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: BSD-3-Clause
 
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
+## 2.2.1 -
+
+### Fixed
+- Interop tests throw if the issuer fails to issue a Vc.
+
 ## 2.2.0 - 2024-01-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 ## 2.2.1 -
 
 ### Fixed
-- Interop tests throw if the issuer fails to issue a Vc.
+- Interop tests throw if the issuer fails to issue a VC.
 
 ## 2.2.0 - 2024-01-03
 

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -2,11 +2,13 @@
  * Copyright 2023 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+import chai from 'chai';
 import {createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {validVc as vc} from './mock-data.js';
 import {verificationSuccess} from './assertions.js';
 
+const should = chai.should();
 const tag = 'ecdsa-rdfc-2019';
 
 // only use implementations with `ecdsa-rdfc-2019` issuers.
@@ -81,6 +83,10 @@ describe('ecdsa-rdfc-2019 (interop)', function() {
             rowId: issuerDisplayName,
             columnId: verifierDisplayName
           };
+          should.exist(
+            issuedVc,
+            `Expected issuer ${issuerDisplayName} to issue a Vc.`
+          );
           await verificationSuccess({
             credential: issuedVc, verifier: verifierEndpoint
           });

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -85,7 +85,7 @@ describe('ecdsa-rdfc-2019 (interop)', function() {
           };
           should.exist(
             issuedVc,
-            `Expected issuer ${issuerDisplayName} to issue a Vc.`
+            `Expected issuer ${issuerDisplayName} to issue a VC.`
           );
           await verificationSuccess({
             credential: issuedVc, verifier: verifierEndpoint

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {createDisclosedVc, createInitialVc} from './helpers.js';
+import chai from 'chai';
 import {endpoints} from 'vc-test-suite-implementations';
 import {holderName} from './test-config.js';
 import {validVc as vc} from './mock-data.js';
 import {verificationSuccess} from './assertions.js';
 
+const should = chai.should();
 const tag = 'ecdsa-sd-2023';
 
 // only use implementations with `ecdsa-sd-2023` issuers.
@@ -95,6 +97,10 @@ describe('ecdsa-sd-2023 (interop)', function() {
             rowId: issuerDisplayName,
             columnId: verifierDisplayName
           };
+          should.exist(
+            disclosedCredential,
+            `Expected issuer ${issuerDisplayName} to issue a disclosed Vc.`
+          );
           await verificationSuccess({
             credential: disclosedCredential, verifier: verifierEndpoint
           });

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -99,7 +99,7 @@ describe('ecdsa-sd-2023 (interop)', function() {
           };
           should.exist(
             disclosedCredential,
-            `Expected issuer ${issuerDisplayName} to issue a disclosed Vc.`
+            `Expected issuer ${issuerDisplayName} to issue a disclosed VC.`
           );
           await verificationSuccess({
             credential: disclosedCredential, verifier: verifierEndpoint


### PR DESCRIPTION
Currently the interop tests will just pass an empty credential to a verifier if the an issuer fails to issue a Vc.
This PR fixes that, by throwing so that in the interop report an implementer will see that the interop issue
occurred because the issuer of the Vc failed and not their verifier itself.