### PR TITLE
Expand implementation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ to your implementation manifest.
     in the tests.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
-- An optional `vcHolder` endpoint maybe added for `ecdsa-sd-2023` selective disclosure tests.
-  - The vcHolder endpoint route should be `/credentials/derive`
-  - The endpoint needs to accept a JSON object with 2 properties:
+- An optional `vcHolder` endpoint can be added for `ecdsa-sd-2023` selective disclosure tests.
+  - The vcHolder endpoint route is meant to be `/credentials/derive`
+  - The endpoint is expected to accept a JSON object with 2 properties:
     - `options` which is a JSON object.
     - `options.selectivePointers` which is an array of strings.
-    - `verifiableCredential` which is a previously signed JSON VC.
-    - The endpoint needs to use `ecdsa-sd-2023` for the derived VC.
+    - `verifiableCredential` which is a previously signed JSON verifiable credential.
+    - The endpoint needs to use `ecdsa-sd-2023` for the derived verifiable credential.
 
 All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you

--- a/README.md
+++ b/README.md
@@ -112,8 +112,11 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
-  - The issuer id will be used as the issuer property on verifiable credentials
+  - An optional id property specifying the issuer can be set alongside the endpoint.
+  - If provided, the specified issuer id will be used as the issuer property on verifiable credentials
     in the tests.
+  - The issuer id should be easy for other implementers to dereference.
+    - It is recommended the issuer id be either `did:key` or `did:web`.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
 - An optional `vcHolder` endpoint can be added for `ecdsa-sd-2023` selective disclosure tests.
@@ -140,13 +143,13 @@ A simplified manifest would look like this:
   "name": "My Company",
   "implementation": "My implementation",
   "issuers": [{
-    "id": "did:key:myIssuer1",
+    "id": "did:key:myIssuer1#keyFragment",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": ["ecdsa-rdfc-2019"]
   }, {
-    "id": "did:key:myIssuer2",
+    "id": "did:web:myIssuer.dev#issuer2",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256"]
@@ -159,7 +162,6 @@ A simplified manifest would look like this:
     "tags": ["ecdsa-sd-2023"]
   }],
   "verifiers": [{
-    "id": "did:key:myVerifier1",
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256", "P-384"]
@@ -168,7 +170,7 @@ A simplified manifest would look like this:
     ]
   }],
   "vcHolders": [{
-    "id": "did:key:myHolder1",
+    "id": "did:key:myIssuer1#keyFragment",
     "endpoint": "https://mycompany.example/credentials/derive",
     "tags": ["vcHolder"]
   }]

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ property.
 
 All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you
-must also specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
+will need to specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
 listing the ECDSA key types issuable or verifiable by your implementation.
 Currently, the test suite supports `P-256` and `P-384` ECDSA key types.
 A `vcHolder` tag is required for the `vcHolder` endpoints.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
-  - The issuer id will be used as the issuer property on VCs in the tests.
+  - The issuer id will be used as the issuer property on verifiable credentials
+    in the tests.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
 - An optional `vcHolder` endpoint maybe added for `ecdsa-sd-2023` selective disclosure tests.

--- a/README.md
+++ b/README.md
@@ -76,12 +76,11 @@ module.exports = [{
   name: 'My Company',
   implementation: 'My Implementation Name',
   issuers: [{
-    id: 'did:myMethod:implementation:issuer:id',
+    id: 'did:key:zMyKey',
     endpoint: `${baseUrl}/credentials/issue`,
     tags: ['ecdsa-rdfc-2019', 'localhost']
   }],
   verifiers: [{
-    id: 'did:myMethod:implementation:verifier:id',
     endpoint: `${baseUrl}/credentials/verify`,
     tags: ['ecdsa-rdfc-2019', 'localhost']
   }]
@@ -116,7 +115,7 @@ to your implementation manifest.
   - If provided, the specified issuer id will be used as the issuer property on verifiable credentials
     in the tests.
   - The issuer id should be easy for other implementers to dereference.
-    - It is recommended the issuer id be either `did:key` or `did:web`.
+    - It is recommended the issuer id be `did:key`.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
 - An optional `vcHolder` endpoint can be added for `ecdsa-sd-2023` selective disclosure tests.
@@ -149,7 +148,7 @@ A simplified manifest would look like this:
     "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": ["ecdsa-rdfc-2019"]
   }, {
-    "id": "did:web:myIssuer.dev#issuer2",
+    "id": "did:key:myIssuer#issuer2",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256"]

--- a/README.md
+++ b/README.md
@@ -112,11 +112,15 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
-  - The issuer id will be used as the issuer in VCs in the tests.
+  - The issuer id will be used as the issuer property on VCs in the tests.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
 - An optional `vcHolder` endpoint maybe added for `ecdsa-sd-2023` selective disclosure tests.
-  - The hcHolder id will be used as the issuer in VCs in the tests.
+  - The vcHolder endpoint route should be `/credentials/derive`
+  - The endpoint needs to accept a JSON object with 2 properties:
+    - `options.selectivePointers` with is an array of strings.
+    - `verifiableCredential` which is a previously signed JSON VC.
+    - The endpoint needs to use `ecdsa-sd-2023` for the derived VC.
 
 All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you

--- a/README.md
+++ b/README.md
@@ -111,11 +111,10 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
-  - An optional id property specifying the issuer can be set alongside the endpoint.
-  - If provided, the specified issuer id will be used as the issuer property on verifiable credentials
+  - An optional `id` property may be set alongside the `endpoint`.
+  - If provided, the specified `issuer.id` will be added to Verifiable Credentials
     in the tests.
-  - The issuer id should be easy for other implementers to dereference.
-    - It is recommended the issuer id be `did:key`.
+  - If present, the `issuer.id` MUST use the `did:key` method and MUST dereferenceable.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
 - An optional `vcHolder` endpoint can be added for `ecdsa-sd-2023` selective disclosure tests.

--- a/README.md
+++ b/README.md
@@ -112,14 +112,18 @@ with `DataIntegrityProof` proof type using the `ecdsa-rdfc-2019`,
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
 - A credential issuer endpoint (`/credentials/issue`) in the `issuers` property.
+  - The issuer id will be used as the issuer in VCs in the tests.
 - A credential verifier endpoint (`/credentials/verify`) in the `verifiers`
 property.
+- An optional `vcHolder` endpoint maybe added for `ecdsa-sd-2023` selective disclosure tests.
+  - The hcHolder id will be used as the issuer in VCs in the tests.
 
 All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you
 must also specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
 listing the ECDSA key types issuable or verifiable by your implementation.
 Currently, the test suite supports `P-256` and `P-384` ECDSA key types.
+A `vcHolder` tag is required for the `vcHolder` endpoints.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
 
@@ -130,32 +134,37 @@ A simplified manifest would look like this:
   "name": "My Company",
   "implementation": "My implementation",
   "issuers": [{
-    "id": "",
+    "id": "did:key:myIssuer1",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": ["ecdsa-rdfc-2019"]
   }, {
-    "id": "",
+    "id": "did:key:myIssuer2",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256"]
     "tags": ["ecdsa-jcs-2019"]
   }, {
-    "id": "",
+    "id": "did:key:myIssuer3",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256"]
     "tags": ["ecdsa-sd-2023"]
   }],
   "verifiers": [{
-    "id": "",
+    "id": "did:key:myVerifier1",
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
     "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": [
       "ecdsa-rdfc-2019", "ecdsa-jcs-2019", "ecdsa-sd-2023"
     ]
+  }],
+  "vcHolders": [{
+    "id": "did:key:myHolder1",
+    "endpoint": "https://mycompany.example/credentials/derive",
+    "tags": ["vcHolder"]
   }]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ property.
 - An optional `vcHolder` endpoint maybe added for `ecdsa-sd-2023` selective disclosure tests.
   - The vcHolder endpoint route should be `/credentials/derive`
   - The endpoint needs to accept a JSON object with 2 properties:
-    - `options.selectivePointers` with is an array of strings.
+    - `options` which is a JSON object.
+    - `options.selectivePointers` which is an array of strings.
     - `verifiableCredential` which is a previously signed JSON VC.
     - The endpoint needs to use `ecdsa-sd-2023` for the derived VC.
 


### PR DESCRIPTION
Expands the implementation instructions:

1. Adds an id to all endpoints
2. Clarifies that the issuer id is used in test data
3. Adds the `derive` endpoint to implementations