### PR TITLE
Separate di tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 ### Changed
 - The env variables for specifying the issuer for the RDFC & SD tests are now separate.
 - The env variable for specifying the holder for the SD tests is now `SD_HOLDER_NAME`.
-- Data Integrity tests are now separate in their own file and can be run separately.
+- Data Integrity tests are now in their own file and can be run separately.
 
 ## 2.2.1 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ SPDX-License-Identifier: BSD-3-Clause
 ### Changed
 - The env variables for specifying the issuer for the RDFC & SD tests are now separate.
 - The env variable for specifying the holder for the SD tests is now `SD_HOLDER_NAME`.
+- Data Integrity tests are now separate in their own file and can be run separately.
 
 ## 2.2.1 -
 

--- a/tests/05-rdfc-di-create.js
+++ b/tests/05-rdfc-di-create.js
@@ -15,10 +15,8 @@ const {match} = endpoints.filterByTag({
   property: 'issuers'
 });
 
-describe('ecdsa-rdfc-2019 Data Integrity (create)', function() {
-  checkDataIntegrityProofFormat({
-    implemented: match,
-    isEcdsaTests: true,
-    testDescription: 'Data Integrity (ecdsa-rdfc-2019 issuers)'
-  });
-})
+checkDataIntegrityProofFormat({
+  implemented: match,
+  isEcdsaTests: true,
+  testDescription: 'Data Integrity (ecdsa-rdfc-2019 issuers)'
+});

--- a/tests/05-rdfc-di-create.js
+++ b/tests/05-rdfc-di-create.js
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  checkDataIntegrityProofFormat
+} from 'data-integrity-test-suite-assertion';
+import {endpoints} from 'vc-test-suite-implementations';
+import {getSuiteConfig} from './test-config.js';
+
+const {tags} = getSuiteConfig('ecdsa-rdfc-2019');
+const {match} = endpoints.filterByTag({
+  tags: [...tags],
+  property: 'issuers'
+});
+
+describe('ecdsa-rdfc-2019 Data Integrity (create)', function() {
+  checkDataIntegrityProofFormat({
+    implemented: match,
+    isEcdsaTests: true,
+    testDescription: 'Data Integrity (ecdsa-rdfc-2019 issuers)'
+  });
+})

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -7,9 +7,6 @@ import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
 import chai from 'chai';
-import {
-  checkDataIntegrityProofFormat
-} from 'data-integrity-test-suite-assertion';
 import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
@@ -22,11 +19,6 @@ const {match} = endpoints.filterByTag({
 const should = chai.should();
 
 describe('ecdsa-rdfc-2019 (create)', function() {
-  checkDataIntegrityProofFormat({
-    implemented: match,
-    isEcdsaTests: true,
-    testDescription: 'Data Integrity (ecdsa-rdfc-2019 issuers)'
-  });
   describe('ecdsa-rdfc-2019 (issuers)', function() {
     this.matrix = true;
     this.report = true;

--- a/tests/15-rdfc-di-verify.js
+++ b/tests/15-rdfc-di-verify.js
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2023 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {
+  checkDataIntegrityProofVerifyErrors
+} from 'data-integrity-test-suite-assertion';
+import {endpoints} from 'vc-test-suite-implementations';
+import {getSuiteConfig} from './test-config.js';
+
+const {tags} = getSuiteConfig('ecdsa-rdfc-2019');
+
+// only use implementations with `ecdsa-rdfc-2019` verifiers.
+const {match} = endpoints.filterByTag({
+  tags: [...tags],
+  property: 'verifiers'
+});
+
+describe('ecdsa-rdfc-2019 Data Integrity (verify)', function() {
+  checkDataIntegrityProofVerifyErrors({
+    implemented: match,
+    isEcdsaTests: true,
+    testDescription: 'Data Integrity (ecdsa-rdfc-2019 verifiers)'
+  });
+});

--- a/tests/20-rdfc-verify.js
+++ b/tests/20-rdfc-verify.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {verificationFail, verificationSuccess} from './assertions.js';
-import {
-  checkDataIntegrityProofVerifyErrors
-} from 'data-integrity-test-suite-assertion';
 import {createInitialVc} from './helpers.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
@@ -23,11 +20,6 @@ const {match} = endpoints.filterByTag({
 });
 
 describe('ecdsa-rdfc-2019 (verify)', function() {
-  checkDataIntegrityProofVerifyErrors({
-    implemented: match,
-    isEcdsaTests: true,
-    testDescription: 'Data Integrity (ecdsa-rdfc-2019 verifiers)'
-  });
   describe('ecdsa-rdfc-2019 (verifiers)', function() {
     let issuers;
     before(async function() {

--- a/tests/35-sd-di-create.js
+++ b/tests/35-sd-di-create.js
@@ -3,21 +3,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {
-  checkDataIntegrityProofVerifyErrors
+  checkDataIntegrityProofFormat
 } from 'data-integrity-test-suite-assertion';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 
-const {tags} = getSuiteConfig('ecdsa-rdfc-2019');
-
-// only use implementations with `ecdsa-rdfc-2019` verifiers.
+const {tags} = getSuiteConfig('ecdsa-sd-2023');
 const {match} = endpoints.filterByTag({
   tags: [...tags],
-  property: 'verifiers'
+  property: 'issuers'
 });
 
-checkDataIntegrityProofVerifyErrors({
+checkDataIntegrityProofFormat({
   implemented: match,
   isEcdsaTests: true,
-  testDescription: 'Data Integrity (ecdsa-rdfc-2019 verifiers)'
+  testDescription: 'Data Integrity (ecdsa-sd-2023 issuers)'
 });

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -7,9 +7,6 @@ import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
 import chai from 'chai';
-import {
-  checkDataIntegrityProofFormat
-} from 'data-integrity-test-suite-assertion';
 import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
@@ -23,11 +20,6 @@ const {match} = endpoints.filterByTag({
 const should = chai.should();
 
 describe('ecdsa-sd-2023 (create)', function() {
-  checkDataIntegrityProofFormat({
-    implemented: match,
-    isEcdsaTests: true,
-    testDescription: 'Data Integrity (ecdsa-sd-2023 issuers)'
-  });
   describe('ecdsa-sd-2023 (issuers)', function() {
     this.matrix = true;
     this.report = true;

--- a/tests/45-sd-di-verify.js
+++ b/tests/45-sd-di-verify.js
@@ -8,9 +8,9 @@ import {
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 
-const {tags} = getSuiteConfig('ecdsa-rdfc-2019');
+const {tags} = getSuiteConfig('ecdsa-sd-2023');
 
-// only use implementations with `ecdsa-rdfc-2019` verifiers.
+// only use implementations with `ecdsa-sd-2023` verifiers.
 const {match} = endpoints.filterByTag({
   tags: [...tags],
   property: 'verifiers'
@@ -19,5 +19,6 @@ const {match} = endpoints.filterByTag({
 checkDataIntegrityProofVerifyErrors({
   implemented: match,
   isEcdsaTests: true,
-  testDescription: 'Data Integrity (ecdsa-rdfc-2019 verifiers)'
+  testDescription: 'Data Integrity (ecdsa-sd-2023 verifiers)'
 });
+

--- a/tests/50-sd-verify.js
+++ b/tests/50-sd-verify.js
@@ -4,9 +4,6 @@
  */
 import {createDisclosedVc, createInitialVc} from './helpers.js';
 import {verificationFail, verificationSuccess} from './assertions.js';
-import {
-  checkDataIntegrityProofVerifyErrors
-} from 'data-integrity-test-suite-assertion';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 import {klona} from 'klona';
@@ -25,11 +22,6 @@ const {match} = endpoints.filterByTag({
 });
 
 describe('ecdsa-sd-2023 (verify)', function() {
-  checkDataIntegrityProofVerifyErrors({
-    implemented: match,
-    isEcdsaTests: true,
-    testDescription: 'Data Integrity (ecdsa-sd-2023 verifiers)'
-  });
   describe('ecdsa-sd-2023 (verifiers)', function() {
     let issuers;
     let vcHolder;


### PR DESCRIPTION
Separates the data integrity tests from the ecdsa specific normative tests.
This allows the D.I. tests to be ignored, run separately, and other things like that.