### PR TITLE
Patch add vc 2 context vc gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 ### Added
 - **BREAKING**: interop tests are now skipped by default; `LOCAL_ONLY` environment variable set to `false` reenables them.
+- Support for issuing test data locally using VC 2.0 context.
 
 ## 2.3.0 - 2024-02-25
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/w3c/vc-di-ecdsa-test-suite#readme",
   "dependencies": {
+    "@digitalbazaar/credentials-v2-context": "github:digitalbazaar/credentials-v2-context",
     "@digitalbazaar/data-integrity": "^2.1.0",
     "@digitalbazaar/data-integrity-context": "^2.0.0",
     "@digitalbazaar/did-method-key": "^5.1.0",

--- a/tests/vc-generator/contexts.js
+++ b/tests/vc-generator/contexts.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2022-2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+import * as credentialsV2Context from '@digitalbazaar/credentials-v2-context';
 import credentialsCtx from 'credentials-context';
 import dataIntegrityCtx from '@digitalbazaar/data-integrity-context';
 import didCtx from '@digitalcredentials/did-context';
@@ -27,6 +28,12 @@ contextMap.set(
   credentialsCtx.constants.CONTEXT_URL,
   credentialsCtx.contexts.get(
     credentialsCtx.constants.CONTEXT_URL)
+);
+
+contextMap.set(
+  credentialsV2Context.constants.CONTEXT_URL,
+  credentialsV2Context.contexts.get(
+    credentialsV2Context.constants.CONTEXT_URL)
 );
 
 export {contextMap};


### PR DESCRIPTION
Adds the VC 2.0 context to the vc generator so that VC 2.0 credentials can be issued locally.