### PR TITLE
Check for error before result in verifier success assertion.

### DIFF
--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -78,8 +78,8 @@ export const verificationSuccess = async ({credential, verifier}) => {
     }
   };
   const {result, error} = await verifier.post({json: body});
-  should.exist(result, 'Expected a result from verifier.');
   should.not.exist(error, 'Expected verifier to not error.');
+  should.exist(result, 'Expected a result from verifier.');
   should.exist(result.status,
     'Expected verifier to return an HTTP Status code');
   result.status.should.equal(


### PR DESCRIPTION
so it turns out the verificationSuccess assertion checks for a result first and an error second.
The issue is checking for the error first means the error throw from the verifier ends up in the report vs just getting received undefined. As the error contains more information, I have placed it first.