### PR TITLE
Suite determines key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you
 will need to specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
 listing the ECDSA key types issuable or verifiable by your implementation.
-Currently, the test suite supports `P-256` and `P-384` ECDSA key types.
+It is recommended to have one issuer per supported Ecdsa KeyType.
+Currently, the `ecdsa-rdfc-2019` test suite supports `P-256` and `P-384` ECDSA key types.
+The `ecdsa-sd-2023` test suite only supports `P-256`.
+Verifier endpoints should support multiple keyTypes and suites.
 A `vcHolder` tag is required for the `vcHolder` endpoints.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.
@@ -176,33 +179,39 @@ A simplified manifest would look like this:
   "name": "My Company",
   "implementation": "My implementation",
   "issuers": [{
-    "id": "did:key:myIssuer1#keyFragment",
-    "endpoint": "https://mycompany.example/credentials/issue",
+    "id": "did:key:myIssuer1#p256",
+    "endpoint": "https://mycompany.example/issuer/p256/credentials/issue",
     "method": "POST",
-    "supportedEcdsaKeyTypes": ["P-256", "P-384"]
+    "supportedEcdsaKeyTypes": ["P-256"],
+    "tags": ["ecdsa-rdfc-2019"]
+  },{
+    "id": "did:key:myIssuer1#p384",
+    "endpoint": "https://mycompany.example/issuer/p384/credentials/issue",
+    "method": "POST",
+    "supportedEcdsaKeyTypes": ["P-384"],
     "tags": ["ecdsa-rdfc-2019"]
   }, {
     "id": "did:key:myIssuer#issuer2",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "supportedEcdsaKeyTypes": ["P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
     "tags": ["ecdsa-jcs-2019"]
   }, {
     "id": "did:key:myIssuer3",
     "endpoint": "https://mycompany.example/credentials/issue",
     "method": "POST",
-    "supportedEcdsaKeyTypes": ["P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
     "tags": ["ecdsa-sd-2023"]
   }],
   "verifiers": [{
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
-    "supportedEcdsaKeyTypes": ["P-256", "P-384"]
+    "supportedEcdsaKeyTypes": ["P-256", "P-384"],
     "tags": ["ecdsa-rdfc-2019", "ecdsa-jcs-2019"]
   }, {
     "endpoint": "https://mycompany.example/credentials/verify",
     "method": "POST",
-    "supportedEcdsaKeyTypes": ["P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
     "tags": ["ecdsa-sd-2023"]
   }],
   "vcHolders": [{

--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ All endpoints will require a cryptosuite tag of `ecdsa-rdfc-2019`,
 `ecdsa-jcs-2019`, and/or `ecdsa-sd-2023`. Alongside this cryptosuite tag, you
 will need to specify the `supportedEcdsaKeyTypes` property, parallel to `tags`
 listing the ECDSA key types issuable or verifiable by your implementation.
-It is recommended to have one issuer per supported Ecdsa KeyType.
+It is recommended to have one issuer per supported ECDSA key type.
 Currently, the `ecdsa-rdfc-2019` test suite supports `P-256` and `P-384` ECDSA key types.
-The `ecdsa-sd-2023` test suite only supports `P-256`.
-Verifier endpoints should support multiple keyTypes and suites.
+The `ecdsa-sd-2023` test suite only supports the `P-256` ECDSA key type.
+Verifier endpoints can support multiple keys, key types, and suites.
 A `vcHolder` tag is required for the `vcHolder` endpoints.
 
 NOTE: The tests for `ecdsa-jcs-2019` are TBA.

--- a/config/runner.json
+++ b/config/runner.json
@@ -2,9 +2,11 @@
   "local": true,
   "suites": {
     "ecdsa-rdfc-2019": {
+      "supportedKeyTypes": ["P-256", "P-384"],
       "tags": ["ecdsa-rdfc-2019"]
     },
     "ecdsa-sd-2023": {
+      "supportedKeyTypes": ["P-256"],
       "tags": ["ecdsa-sd-2023"],
       "vcHolder": {
         "holderName": "Digital Bazaar",

--- a/config/runner.json
+++ b/config/runner.json
@@ -2,11 +2,9 @@
   "local": true,
   "suites": {
     "ecdsa-rdfc-2019": {
-      "supportedKeyTypes": ["P-256", "P-384"],
       "tags": ["ecdsa-rdfc-2019"]
     },
     "ecdsa-sd-2023": {
-      "supportedKeyTypes": ["P-256"],
       "tags": ["ecdsa-sd-2023"],
       "vcHolder": {
         "holderName": "Digital Bazaar",

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -11,7 +11,7 @@ import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 
-const {tags, credentials} = getSuiteConfig('ecdsa-rdfc-2019');
+const {tags, credentials, keyTypes} = getSuiteConfig('ecdsa-rdfc-2019');
 const {match} = endpoints.filterByTag({
   tags: [...tags],
   property: 'issuers'
@@ -31,7 +31,11 @@ describe('ecdsa-rdfc-2019 (create)', function() {
         const {supportedEcdsaKeyTypes} = issuer.settings;
         // test for each support key type
         for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
-          const keyType = checkKeyType(supportedEcdsaKeyType);
+          // throw if this suite doesn't support a keyType
+          const keyType = checkKeyType({
+            keyType: supportedEcdsaKeyType,
+            supportedKeyTypes: keyTypes
+          });
           // add implementer name and keyType to test report
           this.implemented.push(`${name}: ${keyType}`);
           describe(`${name}: ${keyType}`, function() {

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -2,11 +2,11 @@
  * Copyright 2023 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {checkKeyType, createInitialVc} from './helpers.js';
 import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
 import chai from 'chai';
+import {createInitialVc} from './helpers.js';
 import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
@@ -26,16 +26,15 @@ describe('ecdsa-rdfc-2019 (create)', function() {
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints: issuers, implementation}] of match) {
+      // test for each support key type
+      for(const keyType of keyTypes) {
       // loop through each issuer in suite
-      for(const issuer of issuers) {
-        const {supportedEcdsaKeyTypes} = issuer.settings;
-        // test for each support key type
-        for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
-          // throw if this suite doesn't support a keyType
-          const keyType = checkKeyType({
-            keyType: supportedEcdsaKeyType,
-            supportedKeyTypes: keyTypes
-          });
+        for(const issuer of issuers) {
+          const {supportedEcdsaKeyTypes} = issuer.settings;
+          // if an issuer does not support the current keyType skip it
+          if(!supportedEcdsaKeyTypes.includes(keyType)) {
+            continue;
+          }
           // add implementer name and keyType to test report
           this.implemented.push(`${name}: ${keyType}`);
           describe(`${name}: ${keyType}`, function() {

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -2,11 +2,11 @@
  * Copyright 2023 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {checkKeyType, createInitialVc} from './helpers.js';
 import {
   shouldBeBs58, shouldBeMulticodecEncoded, verificationSuccess
 } from './assertions.js';
 import chai from 'chai';
+import {createInitialVc} from './helpers.js';
 import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
@@ -27,14 +27,13 @@ describe('ecdsa-sd-2023 (create)', function() {
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints: issuers, implementation}] of match) {
-      for(const issuer of issuers) {
-        const {supportedEcdsaKeyTypes} = issuer.settings;
-        for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
-          // throw if this suite doesn't support a keyType
-          const keyType = checkKeyType({
-            keyType: supportedEcdsaKeyType,
-            supportedKeyTypes: keyTypes
-          });
+      for(const keyType of keyTypes) {
+        for(const issuer of issuers) {
+          const {supportedEcdsaKeyTypes} = issuer.settings;
+          // if an issuer does not support the current keyType skip it
+          if(!supportedEcdsaKeyTypes.includes(keyType)) {
+            continue;
+          }
           // add implementation name and keyType to report
           this.implemented.push(`${name}: ${keyType}`);
           describe(`${name}: ${keyType}`, function() {

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -11,7 +11,7 @@ import {documentLoader} from './documentLoader.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 
-const {tags, credentials} = getSuiteConfig('ecdsa-sd-2023');
+const {tags, credentials, keyTypes} = getSuiteConfig('ecdsa-sd-2023');
 const {match} = endpoints.filterByTag({
   tags: [...tags],
   property: 'issuers'
@@ -30,7 +30,11 @@ describe('ecdsa-sd-2023 (create)', function() {
       for(const issuer of issuers) {
         const {supportedEcdsaKeyTypes} = issuer.settings;
         for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
-          const keyType = checkKeyType(supportedEcdsaKeyType);
+          // throw if this suite doesn't support a keyType
+          const keyType = checkKeyType({
+            keyType: supportedEcdsaKeyType,
+            supportedKeyTypes: keyTypes
+          });
           // add implementation name and keyType to report
           this.implemented.push(`${name}: ${keyType}`);
           describe(`${name}: ${keyType}`, function() {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -66,8 +66,7 @@ export const multibaseMultikeyHeaderP256 =
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
 
-export function checkKeyType(keyType) {
-  const supportedKeyTypes = ['P-256', 'P-384'];
+export function checkKeyType({keyType, supportedKeyTypes}) {
   if(supportedKeyTypes.includes(keyType)) {
     return keyType;
   }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -65,10 +65,3 @@ export const multibaseMultikeyHeaderP256 =
 
 export const multibaseMultikeyHeaderP384 =
   SUPPORTED_BASE58_ECDSA_MULTIKEY_HEADERS.get('P-384');
-
-export function checkKeyType({keyType, supportedKeyTypes}) {
-  if(supportedKeyTypes.includes(keyType)) {
-    return keyType;
-  }
-  throw new Error(`Unsupported ECDSA key type: ${keyType}.`);
-}


### PR DESCRIPTION
1. Corrects a known issue where tests could loop testing the same endpoint repetitively
2. Uses an existing config option to ensure tests only test keyTypes that suite supports
3. Expands the README with better clarification of how the keyTypes work with `ecdsa-rdfc-2019` and `ecdsa-sd-2023`


![Screenshot 2024-03-20 at 3 07 44 PM](https://github.com/w3c/vc-di-ecdsa-test-suite/assets/278280/c83b616f-56f1-4b1d-91ea-5fdf08b6c93b)

p.s. this does not change the existing way multiple keyTypes show up in the report it mostly just fixes the way keyTypes interact with the test suite.