### PR TITLE
Clarify local testing; clean readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,5 @@ reports/**
 !.gitkeep
 credentials/*.json
 .vscode
-.localImplementationsConfig.cjs
-localImplementationsConfig.cjs
+localConfig.cjs
 tests/input/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ SPDX-License-Identifier: BSD-3-Clause
 - **BREAKING**: Env variables related to `issuerName` no longer used.
 
 ### Added
-- **BREAKING**: interop tests are now skipped by default; `LOCAL_ONLY` environment variable set to `false` reenables them.
+- **BREAKING**: interop tests are now skipped by default; `DISABLE_INTEROP_TESTS`
+environment variable set to `false` reenables them.
 - Support for issuing test data locally using VC 2.0 context.
 - Support for running issuer-specific tests against an in-process verifier.
 - RDFC verify tests now assert against required `keyType`s rather
 than only testing what is marked by `supportedEcdsaKeyTypes` as
 supported by integration.
+- Support for a new `localConfig.cjs` feature.
+  - Adds options for test suite config and local implementation endpoint configuration.
 
 ## 2.3.0 - 2024-02-25
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 
 ### Testing Locally
 
-If you want to test a single implementation or endpoints running locally, you can
+To test a single implementation or endpoint running locally, you can
 copy `localConfig.example.cjs` to `localConfig.cjs`
 in the root directory of the test suite.
 
@@ -158,10 +158,10 @@ This file must be a CommonJS module that exports an object containing a
 `implementations` array (for configuring the implementation(s) to test against).
 
 The format of the object contained in the `implementations` array is
-identical to the on defined in
+identical to the one defined in
 [VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)).
-The `implementations` array may contain more than one implementation object for
-testing multiple implementations at once.
+The `implementations` array may contain more than one implementation object, to
+test multiple implementations in one run.
 
 ```js
 // .localConfig.cjs defining local implementations
@@ -194,9 +194,9 @@ module.exports = {
 ### Running Interoperability Tests
 
 Running interoperability tests requires having authorization to the endpoints of multiple
-implementations. Because most users of this suite will not have those authorization capabilities
-the interoperability suites are disabled by default. If you wish to try running the interoperability suites
-you may by setting `local: false` in `./config/runner.json` or using the ENV Variable `LOCAL_ONLY=false`.
+implementations. Because most users of this suite will not have those authorization capabilities,
+the interoperability suites are disabled by default. You can try running the interoperability suites
+by setting `local: false` in `./config/runner.json` or by setting the Environment Variable `LOCAL_ONLY=false`.
 
 ```bash
 LOCAL_ONLY=false npm test
@@ -211,10 +211,10 @@ The suites call on a set of common config files stored at `./config/`.
 - `./config/runner.json` is for test suite specific configurations.
 - `./config/vector.json` is for test vector specific configurations.
 
-These test suites use tags matched to implementations' endpoint tags in the tests.
+These test suites use tags matched to implementation endpoint tags in the tests.
 You can change the tag on which the suites will run in `./config/runner.json`, if desired.
 
-For this suite the `runner.json` file looks like this:
+For this suite, the `runner.json` file looks like this:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ SPDX-License-Identifier: BSD-3-Clause
 - [Background](#background)
 - [Implementation](#implementation)
 - [Usage](#usage)
-  - [Running Specific Tests](#running-specific-tests)
   - [Testing Locally](#testing-locally)
   - [Running Interoperability Tests](#running-interoperability-tests)
 - [Development](#development)
@@ -130,17 +129,6 @@ require client secrets, please check the implementation manifest within the
 
 ```js
 npm i
-```
-
-### Running Specific Tests
-
-This suite uses [`mocha.js`](https://mochajs.org) as the test runner.
-Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.
-
-For example, the snippet below uses `grep` to filter tests by name, and only runs one of the test suites.
-
-```bash
-mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 ```
 
 ### Testing Locally

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ test multiple implementations in one run.
 const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
 module.exports = {
   settings: {
-    interop_tests: false,
-    local_implementations_only: true
+    enableInteropTests: false, // default
+    testAllImplementations: false // default
   },
   implementations: [{
     name: 'My Company',
@@ -168,12 +168,12 @@ module.exports = {
     issuers: [{
       id: 'did:key:zMyKey',
       endpoint: `${baseUrl}/credentials/issue`,
-      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      supportedEcdsaKeyTypes: ['P-256'],
       tags: ['ecdsa-rdfc-2019']
     }],
     verifiers: [{
       endpoint: `${baseUrl}/credentials/verify`,
-      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      supportedEcdsaKeyTypes: ['P-256'],
       tags: ['ecdsa-rdfc-2019']
     }]
   }];

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ SPDX-License-Identifier: BSD-3-Clause
   - [Running Specific Tests](#running-specific-tests)
   - [Testing Locally](#testing-locally)
   - [Running Interoperability Tests](#running-interoperability-tests)
-  - [Docker Integration (TODO)](#docker-integration-todo)
 - [Development](#development)
   - [Configuring the Tests](#configuring-the-tests)
   - [Configuring Test Vectors](#configuring-test-vectors)
@@ -191,14 +190,6 @@ you may by setting `local: false` in `./config/runner.json` or using the ENV Var
 ```bash
 LOCAL_ONLY=false npm test
 ```
-
-### Docker Integration (TODO)
-
-We are presently working on implementing a new feature that will enable the
-use of Docker images instead of live endpoints. The Docker image that
-you provide will be started when the test suite is run. The image is expected
-to expose the API provided above, which will be used in the same way that
-live HTTP endpoints are used above.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -146,38 +146,49 @@ mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 ### Testing Locally
 
 If you want to test a single implementation or endpoints running locally, you can
-copy `localImplementationsConfig.example.cjs` to `.localImplementationsConfig.cjs`
+copy `localConfig.example.cjs` to `localConfig.cjs`
 in the root directory of the test suite.
 
 ```bash
-cp localImplementationsConfig.example.cjs .localImplementationsConfig.cjs
+cp localConfig.example.cjs localConfig.cjs
 ```
 
-This file must be a CommonJS module that exports an array of implementations
-(the format is identical to the on defined in
-[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)):
+This file must be a CommonJS module that exports an object containing a
+`settings` object (for configuring the test suite code itself) and an
+`implementations` array (for configuring the implementation(s) to test against).
+
+The format of the object contained in the `implementations` array is
+identical to the on defined in
+[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)).
+The `implementations` array may contain more than one implementation object for
+testing multiple implementations at once.
 
 ```js
-// .localImplementationsConfig.cjs defining local implementations
+// .localConfig.cjs defining local implementations
 // you can specify a BASE_URL before running the tests such as:
 // BASE_URL=http://localhost:40443/zDdfsdfs npm test
 const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
-module.exports = [{
-  name: 'My Company',
-  implementation: 'My Implementation Name',
-  // only this implementation will be run in the suite
-  issuers: [{
-    id: 'did:key:zMyKey',
-    endpoint: `${baseUrl}/credentials/issue`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019']
-  }],
-  verifiers: [{
-    endpoint: `${baseUrl}/credentials/verify`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019']
-  }]
-}];
+module.exports = {
+  settings: {
+    interop_tests: false,
+    local_implementations_only: true
+  },
+  implementations: [{
+    name: 'My Company',
+    implementation: 'My Implementation Name',
+    // only this implementation will be run in the suite
+    issuers: [{
+      id: 'did:key:zMyKey',
+      endpoint: `${baseUrl}/credentials/issue`,
+      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      tags: ['ecdsa-rdfc-2019']
+    }],
+    verifiers: [{
+      endpoint: `${baseUrl}/credentials/verify`,
+      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      tags: ['ecdsa-rdfc-2019']
+    }]
+  }];
 ```
 
 ### Running Interoperability Tests

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 
 ### Testing Locally
 
-If you want to test implementations or just endpoints running locally, you can
-copy `localImplementationsConfig.example.cjs` to `localImplementationsConfig.cjs`
+If you want to test a single implementation or endpoints running locally, you can
+copy `localImplementationsConfig.example.cjs` to `.localImplementationsConfig.cjs`
 in the root directory of the test suite.
 
 ```bash
-cp localImplementationsConfig.example.cjs localImplementationsConfig.cjs
+cp localImplementationsConfig.example.cjs .localImplementationsConfig.cjs
 ```
 
-Git is set to ignore `localImplementationsConfig.cjs` & `.localImplementationsConfig.cjs` by default.
-
-This file must be a CommonJS module that exports an array of implementations:
+This file must be a CommonJS module that exports an array of implementations
+(the format is identical to the on defined in
+[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)):
 
 ```js
 // .localImplementationsConfig.cjs defining local implementations
@@ -74,7 +74,6 @@ module.exports = [{
   name: 'My Company',
   implementation: 'My Implementation Name',
   // only this implementation will be run in the suite
-  only: true,
   issuers: [{
     id: 'did:key:zDna',
     endpoint: `${baseUrl}/credentials/issue`,
@@ -83,7 +82,7 @@ module.exports = [{
   }, {
     id: 'did:key:z82L',
     endpoint: `${baseUrl}/credentials/issue`,
-    supportedEcdsaKeyTypes: ['P-384'],
+    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
     tags: ['ecdsa-rdfc-2019']
   }],
   verifiers: [{
@@ -93,9 +92,6 @@ module.exports = [{
   }]
 }];
 ```
-
-After adding the configuration file, both the localhost implementations and other
-implementations matching the test tag will be included in the test run.
 
 ### Configuring the Tests
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,7 @@ module.exports = {
 Running interoperability tests requires having authorization to the endpoints of multiple
 implementations. Because most users of this suite will not have those authorization capabilities,
 the interoperability suites are disabled by default. You can try running the interoperability suites
-by setting `local: false` in `./config/runner.json` or by setting the Environment Variable `LOCAL_ONLY=false`.
-
-```bash
-LOCAL_ONLY=false npm test
-```
+by adding `enableInteropTests: true` to your `localConfig.cjs` file.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ SPDX-License-Identifier: BSD-3-Clause
 ## Table of Contents
 
 - [Background](#background)
-- [Install](#install)
-- [Usage](#usage)
-  - [Running Specific Tests](#Running-Specific-Tests)
-  - [Testing Locally](#testing-locally)
-  - [Configuring the Tests](#Configuring-the-tests)
-  - [Configuring Test Vectors](#Configuring-test-vectors)
-  - [Running Interoperability Tests](#Running-Interoperability-Tests)
 - [Implementation](#implementation)
+- [Usage](#usage)
+  - [Running Specific Tests](#running-specific-tests)
+  - [Testing Locally](#testing-locally)
+  - [Running Interoperability Tests](#running-interoperability-tests)
   - [Docker Integration (TODO)](#docker-integration-todo)
+- [Development](#development)
+  - [Configuring the Tests](#configuring-the-tests)
+  - [Configuring Test Vectors](#configuring-test-vectors)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -26,112 +26,6 @@ SPDX-License-Identifier: BSD-3-Clause
 Provides interoperability tests for verifiable credential processors
 (issuers and verifiers) that support [ECDSA](https://www.w3.org/TR/vc-di-ecdsa/)
 [Data Integrity](https://www.w3.org/TR/vc-data-integrity/) cryptosuites.
-
-## Install
-
-```js
-npm i
-```
-
-## Usage
-
-The suites call on a set of common config files stored at `./config/`.
-
-- `./config/runner.json` is for test suite specific configurations.
-- `./config/vector.json` is for test vector specific configurations.
-
-### Running Specific Tests
-
-This suite uses [`mocha.js`](https://mochajs.org) as the test runner.
-Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.
-
-For example, the snippet below uses `grep` to filter tests by name, and only runs one of the test suites.
-
-```bash
-mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
-```
-
-### Testing Locally
-
-If you want to test a single implementation or endpoints running locally, you can
-copy `localImplementationsConfig.example.cjs` to `.localImplementationsConfig.cjs`
-in the root directory of the test suite.
-
-```bash
-cp localImplementationsConfig.example.cjs .localImplementationsConfig.cjs
-```
-
-This file must be a CommonJS module that exports an array of implementations
-(the format is identical to the on defined in
-[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)):
-
-```js
-// .localImplementationsConfig.cjs defining local implementations
-// you can specify a BASE_URL before running the tests such as:
-// BASE_URL=http://localhost:40443/zDdfsdfs npm test
-const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
-module.exports = [{
-  name: 'My Company',
-  implementation: 'My Implementation Name',
-  // only this implementation will be run in the suite
-  issuers: [{
-    id: 'did:key:zDna',
-    endpoint: `${baseUrl}/credentials/issue`,
-    supportedEcdsaKeyTypes: ['P-256'],
-    tags: ['ecdsa-rdfc-2019']
-  }, {
-    id: 'did:key:z82L',
-    endpoint: `${baseUrl}/credentials/issue`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019']
-  }],
-  verifiers: [{
-    endpoint: `${baseUrl}/credentials/verify`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019']
-  }]
-}];
-```
-
-### Configuring the Tests
-
-These test suites use tags matched to implementations' endpoint tags in the tests.
-You can change the tag on which the suites will run in `./config/runner.json`, if desired.
-
-For this suite the `runner.json` file looks like this:
-
-```js
-{
-  "suites": {
-    "ecdsa-rdfc-2019": {
-      "tags": ["ecdsa-rdfc-2019"]
-    },
-    "ecdsa-sd-2023": {
-      "tags": ["ecdsa-sd-2023"],
-      "vcHolder": {
-        "holderName": "Digital Bazaar",
-        "tags": ["vcHolder"]
-      }
-    }
-  }
-}
-```
-
-### Configuring Test Vectors
-
-The tests use a configuration file `/config/vectors.json` to configure test vectors.
-[Test Vector configuration is documented in testVectorGuide.md,](/testVectorGuide.md)
-
-### Running Interoperability Tests
-
-Running interoperability tests requires having authorization to the endpoints of multiple
-implementations. Because most users of this suite will not have those authorization capabilities
-the interoperability suites are disabled by default. If you wish to try running the interoperability suites
-you can set `DISABLE_INTEROP=false` in your environment variables.
-
-```bash
-LOCAL_ONLY=false npm test
-```
 
 ## Implementation
 
@@ -232,6 +126,72 @@ passed as environment variables to the test script. To see which implementations
 require client secrets, please check the implementation manifest within the
 [vc-test-suite-implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main/implementations) library.
 
+
+## Usage
+
+```js
+npm i
+```
+
+### Running Specific Tests
+
+This suite uses [`mocha.js`](https://mochajs.org) as the test runner.
+Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.
+
+For example, the snippet below uses `grep` to filter tests by name, and only runs one of the test suites.
+
+```bash
+mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
+```
+
+### Testing Locally
+
+If you want to test a single implementation or endpoints running locally, you can
+copy `localImplementationsConfig.example.cjs` to `.localImplementationsConfig.cjs`
+in the root directory of the test suite.
+
+```bash
+cp localImplementationsConfig.example.cjs .localImplementationsConfig.cjs
+```
+
+This file must be a CommonJS module that exports an array of implementations
+(the format is identical to the on defined in
+[VC Test Suite Implementations](https://github.com/w3c/vc-test-suite-implementations?tab=readme-ov-file#usage)):
+
+```js
+// .localImplementationsConfig.cjs defining local implementations
+// you can specify a BASE_URL before running the tests such as:
+// BASE_URL=http://localhost:40443/zDdfsdfs npm test
+const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
+module.exports = [{
+  name: 'My Company',
+  implementation: 'My Implementation Name',
+  // only this implementation will be run in the suite
+  issuers: [{
+    id: 'did:key:zMyKey',
+    endpoint: `${baseUrl}/credentials/issue`,
+    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+    tags: ['ecdsa-rdfc-2019']
+  }],
+  verifiers: [{
+    endpoint: `${baseUrl}/credentials/verify`,
+    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+    tags: ['ecdsa-rdfc-2019']
+  }]
+}];
+```
+
+### Running Interoperability Tests
+
+Running interoperability tests requires having authorization to the endpoints of multiple
+implementations. Because most users of this suite will not have those authorization capabilities
+the interoperability suites are disabled by default. If you wish to try running the interoperability suites
+you may by setting `local: false` in `./config/runner.json` or using the ENV Variable `LOCAL_ONLY=false`.
+
+```bash
+LOCAL_ONLY=false npm test
+```
+
 ### Docker Integration (TODO)
 
 We are presently working on implementing a new feature that will enable the
@@ -239,6 +199,42 @@ use of Docker images instead of live endpoints. The Docker image that
 you provide will be started when the test suite is run. The image is expected
 to expose the API provided above, which will be used in the same way that
 live HTTP endpoints are used above.
+
+## Development
+
+### Configuring the Tests
+
+The suites call on a set of common config files stored at `./config/`.
+
+- `./config/runner.json` is for test suite specific configurations.
+- `./config/vector.json` is for test vector specific configurations.
+
+These test suites use tags matched to implementations' endpoint tags in the tests.
+You can change the tag on which the suites will run in `./config/runner.json`, if desired.
+
+For this suite the `runner.json` file looks like this:
+
+```js
+{
+  "suites": {
+    "ecdsa-rdfc-2019": {
+      "tags": ["ecdsa-rdfc-2019"]
+    },
+    "ecdsa-sd-2023": {
+      "tags": ["ecdsa-sd-2023"],
+      "vcHolder": {
+        "holderName": "Digital Bazaar",
+        "tags": ["vcHolder"]
+      }
+    }
+  }
+}
+```
+
+### Configuring Test Vectors
+
+The tests use a configuration file `/config/vectors.json` to configure test vectors.
+[Test Vector configuration is documented in testVectorGuide.md,](/testVectorGuide.md)
 
 ## Contribute
 

--- a/localConfig.example.cjs
+++ b/localConfig.example.cjs
@@ -4,7 +4,7 @@
 const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
 module.exports = {
   settings: {},
-  implementations: {
+  implementations: [{
     name: 'My Company',
     implementation: 'My Implementation Name',
     issuers: [{
@@ -19,5 +19,5 @@ module.exports = {
       supportedEcdsaKeyTypes: ['P-256', 'P-384'],
       tags: ['ecdsa-rdfc-2019']
     }]
-  }
+  }]
 };

--- a/localConfig.example.cjs
+++ b/localConfig.example.cjs
@@ -1,4 +1,4 @@
-// Rename this file to .localImplementationsConfig.cjs
+// Rename this file to localConfig.cjs
 // you can specify a BASE_URL before running the tests such as:
 // BASE_URL=http://localhost:40443/zDdfsdfs npm test
 const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';

--- a/localConfig.example.cjs
+++ b/localConfig.example.cjs
@@ -2,21 +2,22 @@
 // you can specify a BASE_URL before running the tests such as:
 // BASE_URL=http://localhost:40443/zDdfsdfs npm test
 const baseUrl = process.env.BASE_URL || 'https://localhost:40443/id';
-module.exports = [{
-  name: 'My Company',
-  implementation: 'My Implementation Name',
-  // only this implementation will be run in the suite
-  only: true,
-  issuers: [{
-    id: 'did:myMethod:implementation:issuer:id',
-    endpoint: `${baseUrl}/credentials/issue`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019', 'localhost']
-  }],
-  verifiers: [{
-    id: 'did:myMethod:implementation:verifier:id',
-    endpoint: `${baseUrl}/credentials/verify`,
-    supportedEcdsaKeyTypes: ['P-256', 'P-384'],
-    tags: ['ecdsa-rdfc-2019', 'localhost']
-  }]
-}];
+module.exports = {
+  settings: {},
+  implementations: {
+    name: 'My Company',
+    implementation: 'My Implementation Name',
+    issuers: [{
+      id: 'did:myMethod:implementation:issuer:id',
+      endpoint: `${baseUrl}/credentials/issue`,
+      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      tags: ['ecdsa-rdfc-2019']
+    }],
+    verifiers: [{
+      id: 'did:myMethod:implementation:verifier:id',
+      endpoint: `${baseUrl}/credentials/verify`,
+      supportedEcdsaKeyTypes: ['P-256', 'P-384'],
+      tags: ['ecdsa-rdfc-2019']
+    }]
+  }
+};

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -8,6 +8,9 @@ import {require} from './helpers.js';
 const _runner = require('../config/runner.json');
 const _vectors = require('../config/vectors.json');
 
+// load `localConfig` settings for controlling interop tests
+import {localSettings} from 'vc-test-suite-implementations';
+
 // cache is valid for a single test run
 const _cache = new Map();
 
@@ -20,7 +23,7 @@ const parseInteropOption = () => {
   if(process.env.DISABLE_INTEROP != undefined) {
     return convertToBoolean(process.env.DISABLE_INTEROP);
   }
-  return _runner.local;
+  return !localSettings.enableInteropTests;
 };
 
 const openVectorFiles = vectorFiles => {

--- a/tests/test-config.js
+++ b/tests/test-config.js
@@ -8,7 +8,7 @@ import {require} from './helpers.js';
 const _runner = require('../config/runner.json');
 const _vectors = require('../config/vectors.json');
 
-// load `localConfig` settings for controlling interop tests
+// load `localConfig` settings to control interop tests
 import {localSettings} from 'vc-test-suite-implementations';
 
 // cache is valid for a single test run


### PR DESCRIPTION
- Remove localhost tag and only: true use.
- Heavily reorder the README.
- Remove Docker section.

NOTE: Actual use of this depends upon https://github.com/w3c/vc-test-suite-implementations/pull/30 which is currently pending.
