### PR TITLE
Add normative statement around proof.type from ECDSA spec.

### DIFF
--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -67,8 +67,10 @@ describe('ecdsa-rdfc-2019 (create)', function() {
               }
             });
             /*
-             * @link https://w3c.github.io/vc-di-ecdsa/#verify-derived-proof-ecdsa-sd-2023:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof
-             */
+            @link https://w3c.github.io/vc-di-ecdsa/
+            #verify-derived-proof-ecdsa-sd-2023:~:text=
+            The%20type%20property%20MUST%20be%20DataIntegrityProof
+            */
             it('The type property of the proof MUST be DataIntegrityProof.',
               function() {
                 this.test.cell = {

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -66,6 +66,22 @@ describe('ecdsa-rdfc-2019 (create)', function() {
                 verificationMethodDocuments.push(verificationMethodDocument);
               }
             });
+            it('The type property of the proof MUST be DataIntegrityProof.',
+              function() {
+                this.test.cell = {
+                  columnId: `${name}: ${keyType}`, rowId: this.test.title
+                };
+                proofs.map(p => p?.type).should.contain(
+                  'DataIntegrityProof',
+                  'Expected at least one proof to have type ' +
+                  'DataIntegrityProof');
+              });
+            /*
+             * @link https://w3c.github.io/vc-di-ecdsa/
+             #verify-derived-proof-ecdsa-sd-2023:~:text=
+             The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%
+             2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.
+             */
             it('The cryptosuite property of the proof MUST be ' +
             'ecdsa-rdfc-2019 or ecdsa-jcs-2019.', function() {
               this.test.cell = {

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -71,7 +71,7 @@ describe('ecdsa-rdfc-2019 (create)', function() {
             #verify-derived-proof-ecdsa-sd-2023:~:text=
             The%20type%20property%20MUST%20be%20DataIntegrityProof
             */
-            it('The type property of the proof MUST be DataIntegrityProof.',
+            it('The (proof) type property MUST be DataIntegrityProof.',
               function() {
                 this.test.cell = {
                   columnId: `${name}: ${keyType}`, rowId: this.test.title
@@ -82,12 +82,12 @@ describe('ecdsa-rdfc-2019 (create)', function() {
                   'DataIntegrityProof');
               });
             /*
-             * @link https://w3c.github.io/vc-di-ecdsa/
+             @link https://w3c.github.io/vc-di-ecdsa/
              #verify-derived-proof-ecdsa-sd-2023:~:text=
              The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%
              2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.
              */
-            it('The cryptosuite property of the proof MUST be ' +
+            it('The (proof) cryptosuite property of the proof MUST be ' +
             'ecdsa-rdfc-2019 or ecdsa-jcs-2019.', function() {
               this.test.cell = {
                 columnId: `${name}: ${keyType}`, rowId: this.test.title

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -66,6 +66,9 @@ describe('ecdsa-rdfc-2019 (create)', function() {
                 verificationMethodDocuments.push(verificationMethodDocument);
               }
             });
+            /*
+             * @link https://w3c.github.io/vc-di-ecdsa/#verify-derived-proof-ecdsa-sd-2023:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof
+             */
             it('The type property of the proof MUST be DataIntegrityProof.',
               function() {
                 this.test.cell = {

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -87,7 +87,7 @@ describe('ecdsa-rdfc-2019 (create)', function() {
              The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%
              2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.
              */
-            it('The (proof) cryptosuite property of the proof MUST be ' +
+            it('The cryptosuite property of the proof MUST be ' +
             'ecdsa-rdfc-2019 or ecdsa-jcs-2019.', function() {
               this.test.cell = {
                 columnId: `${name}: ${keyType}`, rowId: this.test.title


### PR DESCRIPTION
Adds missing normative statement which is kind of a duplicate of a data integrity one


https://w3c.github.io/vc-di-ecdsa/#verify-derived-proof-ecdsa-sd-2023:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.