### PR TITLE
Add derive vc fail warning

### DIFF
--- a/config/runner.json
+++ b/config/runner.json
@@ -11,7 +11,7 @@
     "ecdsa-sd-2023": {
       "tags": ["ecdsa-sd-2023"],
       "vcHolder": {
-        "holderName": "Digital Bazaar",
+        "holderName": "Grotto Networking",
         "tags": ["vcHolder"]
       }
     }

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -142,7 +142,6 @@ describe('ecdsa-sd-2023 (create)', function() {
                   };
                   const derivedCredential = await deriveCredential({
                     verifiableCredential: issuedVc,
-                    documentLoader,
                     suite: 'ecdsa-sd-2023',
                     selectivePointers: ['/credentialSubject/id']
                   });

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -84,8 +84,8 @@ const {
         before(async function() {
           const issuedVc = await createInitialVc({
             issuer: issuerEndpoint,
-            vc: credentials.interop['1.1'].document,
-            mandatoryPointers: credentials.interop['1.1'].mandatoryPointers
+            vc: credentials.interop['2.0'].document,
+            mandatoryPointers: credentials.interop['2.0'].mandatoryPointers
           });
           const {match: matchingVcHolders} = endpoints.filterByTag({
             tags: ['vcHolder'],

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -108,7 +108,13 @@ export const verificationSuccess = async ({credential, verifier}) => {
       checks: ['proof']
     }
   };
-  const {result, error} = await verifier.post({json: body});
+  const {result, error, data} = await verifier.post({json: body});
+  if(!result || !result.ok) {
+    console.warn(
+      `Verification failed for ${(result || error)?.requestUrl}`,
+      (error || 'no error thrown'),
+      JSON.stringify({credential, data}, null, 2));
+  }
   should.not.exist(error, 'Expected verifier to not error.');
   should.exist(result, 'Expected a result from verifier.');
   should.exist(result.status,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -46,7 +46,11 @@ export const createInitialVc = async ({issuer, vc, mandatoryPointers}) => {
   }
   const {data, result, error} = await issuer.post({json: body});
   if(!result || !result.ok) {
-    console.warn('initial vc creation failed', {issuer, data, error});
+    console.warn(
+      `initial vc creation failed for ${(result || error)?.requestUrl}`,
+      error,
+      JSON.stringify(data, null, 2)
+    );
     return null;
   }
   return data;
@@ -64,7 +68,11 @@ export const createDisclosedVc = async ({
     }
   });
   if(!result || !result.ok) {
-    console.warn('derived vc creation failed', {vcHolder, data, error});
+    console.warn(
+      `derived vc creation failed for ${(result || error)?.requestUrl}`,
+      error,
+      JSON.stringify(data, null, 2)
+    );
   }
   return {disclosedCredential: data};
 };

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -55,7 +55,7 @@ export const createInitialVc = async ({issuer, vc, mandatoryPointers}) => {
 export const createDisclosedVc = async ({
   selectivePointers = [], signedCredential, vcHolder
 }) => {
-  const {data} = await vcHolder.post({
+  const {data, result, error} = await vcHolder.post({
     json: {
       options: {
         selectivePointers
@@ -63,6 +63,9 @@ export const createDisclosedVc = async ({
       verifiableCredential: signedCredential
     }
   });
+  if(!result || !result.ok) {
+    console.warn('derived vc creation failed', {vcHolder, data, error});
+  }
   return {disclosedCredential: data};
 };
 

--- a/tests/vc-verifier/index.js
+++ b/tests/vc-verifier/index.js
@@ -110,7 +110,7 @@ export const localVerifier = ({cryptosuite}) => ({
         };
       }
 
-      return {result: {...result, status: 200}};
+      return {result: {...result, status: 200, requestUrl: 'local-verifier'}};
     } catch(e) {
       return {
         error: {...e, verified: false, status: 400},


### PR DESCRIPTION
turns a lot of failing sd tests into working sd interop tests. still 2 failing.
This uses Grotto Networking for derive.
This also changes the sd interop tests to only use VC 2.0
corrects a bug in sd-create that was causing localVerifier to throw in every case