### PR TITLE
Do not send issuance date vc2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 # w3c/vc-di-ecdsa-test-suite  ChangeLog
 
-## 3.0.0 - yyyy-mm-dd
+## 3.0.0 - 2024-04-17
 
 ### Changed
 - **BREAKING**: Verify test suites generate data locally.
@@ -23,6 +23,7 @@ than only testing what is marked by `supportedEcdsaKeyTypes` as
 supported by integration.
 - Support for a new `localConfig.cjs` feature.
   - Adds options for test suite config and local implementation endpoint configuration.
+- Test suites test against both VC `1.1` and `2.0` test vectors.
 
 ## 2.3.0 - 2024-02-25
 

--- a/tests/10-rdfc-create.js
+++ b/tests/10-rdfc-create.js
@@ -55,7 +55,8 @@ describe('ecdsa-rdfc-2019 (create)', function() {
               before(async function() {
                 issuedVc = await createInitialVc({
                   issuer,
-                  vc: credentials.create[vcVersion].document
+                  vc: credentials.create[vcVersion].document,
+                  vcVersion
                 });
                 // VCs can have multiple proofs so account for that
                 proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :

--- a/tests/30-rdfc-interop.js
+++ b/tests/30-rdfc-interop.js
@@ -78,7 +78,8 @@ const {
         before(async function() {
           issuedVc = await createInitialVc({
             issuer: issuerEndpoint,
-            vc: credentials.interop['1.1'].document
+            vc: credentials.interop['1.1'].document,
+            vcVersion: '1.1'
           });
         });
         it(`"${verifierDisplayName}" should verify "${issuerDisplayName}"`,

--- a/tests/40-sd-create.js
+++ b/tests/40-sd-create.js
@@ -55,7 +55,8 @@ describe('ecdsa-sd-2023 (create)', function() {
                   issuer,
                   vc: credentials.create[vcVersion].document,
                   mandatoryPointers:
-                   credentials.create[vcVersion].mandatoryPointers
+                   credentials.create[vcVersion].mandatoryPointers,
+                  vcVersion
                 });
                 // Support multiple proofs
                 proofs = Array.isArray(issuedVc?.proof) ? issuedVc.proof :

--- a/tests/60-sd-interop.js
+++ b/tests/60-sd-interop.js
@@ -85,7 +85,8 @@ const {
           const issuedVc = await createInitialVc({
             issuer: issuerEndpoint,
             vc: credentials.interop['2.0'].document,
-            mandatoryPointers: credentials.interop['2.0'].mandatoryPointers
+            mandatoryPointers: credentials.interop['2.0'].mandatoryPointers,
+            vcVersion: '2.0'
           });
           const {match: matchingVcHolders} = endpoints.filterByTag({
             tags: ['vcHolder'],

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -44,7 +44,8 @@ export const createInitialVc = async ({
   const credential = klona(vc);
   credential.id = `urn:uuid:${uuidv4()}`;
   credential.issuer = issuerId;
-  if(vcVersion === '1.1') {
+  const vcNumber = Number(vcVersion);
+  if(vcNumber >= 1 && vcNumber < 2.0) {
     credential.issuanceDate = ISOTimeStamp();
   }
   const body = {credential, options};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -30,15 +30,23 @@ export const ISOTimeStamp = ({date = new Date()} = {}) => {
  * @param {object} options.vc - The credential to be issued.
  * @param {Array<string>} [options.mandatoryPointers] - An optional
  *   array of mandatory pointers.
+ * @param {string} options.vcVersion - The version of the VC.
  *
  * @returns {Promise<object>} The resulting issuance result.
  */
-export const createInitialVc = async ({issuer, vc, mandatoryPointers}) => {
+export const createInitialVc = async ({
+  issuer,
+  vc,
+  mandatoryPointers,
+  vcVersion
+}) => {
   const {settings: {id: issuerId, options = {}}} = issuer;
   const credential = klona(vc);
   credential.id = `urn:uuid:${uuidv4()}`;
   credential.issuer = issuerId;
-  credential.issuanceDate = ISOTimeStamp();
+  if(vcVersion === '1.1') {
+    credential.issuanceDate = ISOTimeStamp();
+  }
   const body = {credential, options};
   // if there are mandatoryPointers for sd tests add them
   if(Array.isArray(mandatoryPointers)) {


### PR DESCRIPTION
corrects a bug where `createInitalVc` was sending `issuanceDate` on VCs with the VC 2.0 context.
issuanceDate is vc 1 only.