### PR TITLE
Allow testing of issuers w/o verifiers.

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -123,6 +123,9 @@ export const endpointCheck = ({endpoint, vcVersion, keyType}) => {
  */
 export function filterVerifiers({implementation}) {
   const endpoints = implementation.verifiers;
+  if(undefined === endpoints) {
+    return [];
+  }
   // the filter function expects an array to be returned
   return endpoints.filter(e => {
     // we want only endpoints that match every tag


### PR DESCRIPTION
The verifier tests should probably show as skipped rather than failed if a verifier is not listed.

However, I wanted to post this now to get feedback. Do we want to support "just issuer" implementations (I think we do)? Currently the code expects both an issuer and a verifier.