### PR TITLE
Add Conformance & Data Model Suites (1)

### DIFF
--- a/tests/70-conformance.js
+++ b/tests/70-conformance.js
@@ -23,16 +23,14 @@ for(const suiteName of cryptosuites) {
       mandatoryPointers,
       selectivePointers
     } = credentials.create[vcVersion];
-    for(const keyType of vectors.keyTypes) {
-      conformanceSuite({
-        verifiers,
-        suiteName,
-        keyType,
-        vcVersion,
-        credential: document,
-        mandatoryPointers,
-        selectivePointers
-      });
-    }
+    conformanceSuite({
+      verifiers,
+      suiteName,
+      keyTypes: vectors.keyTypes,
+      vcVersion,
+      credential: document,
+      mandatoryPointers,
+      selectivePointers
+    });
   }
 }

--- a/tests/70-conformance.js
+++ b/tests/70-conformance.js
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {conformanceSuite} from './suites/conformance.js';
+import {endpoints} from 'vc-test-suite-implementations';
+import {getSuiteConfig} from './test-config.js';
+
+const cryptosuites = [
+  'ecdsa-rdfc-2019',
+  'ecdsa-sd-2023'
+];
+
+for(const suiteName of cryptosuites) {
+  const {tags, credentials, vectors} = getSuiteConfig(suiteName);
+  const {match: verifiers} = endpoints.filterByTag({
+    tags: [...tags],
+    property: 'verifiers'
+  });
+  for(const vcVersion of vectors.vcTypes) {
+    const {
+      document,
+      mandatoryPointers,
+      selectivePointers
+    } = credentials.create[vcVersion];
+    for(const keyType of vectors.keyTypes) {
+      conformanceSuite({
+        verifiers,
+        suiteName,
+        keyType,
+        vcVersion,
+        credential: document,
+        mandatoryPointers,
+        selectivePointers
+      });
+    }
+  }
+}

--- a/tests/80-data-model.js
+++ b/tests/80-data-model.js
@@ -8,7 +8,8 @@ import {getSuiteConfig} from './test-config.js';
 
 const cryptosuites = [
   'ecdsa-rdfc-2019',
-  'ecdsa-jcs-2019'
+  'ecdsa-sd-2023'
+  //FIXME implement jcs 'ecdsa-jcs-2019'
 ];
 
 for(const suiteName of cryptosuites) {

--- a/tests/80-data-model.js
+++ b/tests/80-data-model.js
@@ -24,16 +24,14 @@ for(const suiteName of cryptosuites) {
       mandatoryPointers,
       selectivePointers
     } = credentials.create[vcVersion];
-    for(const keyType of vectors.keyTypes) {
-      dataModelSuite({
-        issuers,
-        suiteName,
-        keyType,
-        vcVersion,
-        credential: document,
-        mandatoryPointers,
-        selectivePointers
-      });
-    }
+    dataModelSuite({
+      issuers,
+      suiteName,
+      keyTypes: vectors.keyTypes,
+      vcVersion,
+      credential: document,
+      mandatoryPointers,
+      selectivePointers
+    });
   }
 }

--- a/tests/80-data-model.js
+++ b/tests/80-data-model.js
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {dataModelSuite} from './suites/data-model.js';
+import {endpoints} from 'vc-test-suite-implementations';
+import {getSuiteConfig} from './test-config.js';
+
+const cryptosuites = [
+  'ecdsa-rdfc-2019',
+  'ecdsa-jcs-2019'
+];
+
+for(const suiteName of cryptosuites) {
+  const {tags, credentials, vectors} = getSuiteConfig(suiteName);
+  const {match: issuers} = endpoints.filterByTag({
+    tags: [...tags],
+    property: 'issuers'
+  });
+  for(const vcVersion of vectors.vcTypes) {
+    const {
+      document,
+      mandatoryPointers,
+      selectivePointers
+    } = credentials.create[vcVersion];
+    for(const keyType of vectors.keyTypes) {
+      dataModelSuite({
+        issuers,
+        suiteName,
+        keyType,
+        vcVersion,
+        credential: document,
+        mandatoryPointers,
+        selectivePointers
+      });
+    }
+  }
+}

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+describe('Conformance', function() {
+  beforeEach(function() {
+
+  });
+  it('Specifically, all relevant normative statements in Sections 2. Data ' +
+  'Model and 3. Algorithms of this document MUST be enforced.', function() {
+    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
+  });
+  it('Conforming processors MUST produce errors when non-conforming ' +
+  'documents are consumed.', function() {
+    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
+  });
+});

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -88,11 +88,13 @@ async function _setup({
   const credentials = new Map();
   const keyPair = await getMultiKey({keyType});
   const signer = keyPair.signer();
+  const _credential = structuredClone(credential);
+  _credential.issuer = keyPair.controller;
   // not bs58 encoded verificationMethod via invalidVm
   // type is not DataIntegrityProof invalidType
   // invalid cryptosuite name invalidCryptosuite
   credentials.set('invalid cryptosuite', await issueCloned(invalidCryptosuite({
-    credential: structuredClone(credential),
+    credential: structuredClone(_credential),
     ..._getSuites({
       signer,
       suiteName,
@@ -101,7 +103,7 @@ async function _setup({
     })
   })));
   credentials.set('invalid VerificationMethod', await issueCloned(invalidVm({
-    credential: structuredClone(credential),
+    credential: structuredClone(_credential),
     ..._getSuites({
       signer,
       suiteName,
@@ -110,7 +112,7 @@ async function _setup({
     })
   })));
   credentials.set('invalid Proof Type', await issueCloned(invalidProofType({
-    credential: structuredClone(credential),
+    credential: structuredClone(_credential),
     ..._getSuites({
       signer,
       suiteName,

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -2,39 +2,56 @@
  * Copyright 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+import {assertions} from 'data-integrity-test-suite-assertion';
 
 export function assertConformance({
-  issuers,
   verifiers,
   suiteName,
   keyType,
   vcVersion,
-  credentials
+  credential,
+  setup = _setup
 }) {
   describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...issuers];
+    this.implemented = [...verifiers];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    for(const [name, {endpoints}] of issuers) {
-      describe(`${name} ${keyType}`, function() {
+    let credentials = new Map();
+    before(async function() {
+      credentials = await setup({credential, suiteName, keyType});
+    });
+    for(const [name, {endpoints}] of verifiers) {
+      const [verifier] = endpoints;
+      describe(`${name}: ${keyType}`, function() {
         beforeEach(function() {
           this.currentTest.cell = {
             rowId: this.currentTest.title,
-            columnId: `${name} ${keyType}`
+            columnId: this.currentTest.parent.title
           };
         });
-        it('Specifically, all relevant normative statements in Sections 2. Data ' +
-        'Model and 3. Algorithms of this document MUST be enforced.', function() {
+        it('Specifically, all relevant normative statements in Sections 2. ' +
+        'Data Model and 3. Algorithms of this document MUST be enforced.',
+        async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
         });
         it('Conforming processors MUST produce errors when non-conforming ' +
-        'documents are consumed.', function() {
+        'documents are consumed.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
+          await assertions.verificationFail({
+            verifier,
+            credential: {},
+            reason: 'Should '
+          });
         });
       });
     }
   });
 }
+async function _setup({}) {
+  // not bs58 encoded verificationMethod
+  // type is not DataIntegrityProof
+  // invalid cryptosuite name
 
+}

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -2,7 +2,12 @@
  * Copyright 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {assertions} from 'data-integrity-test-suite-assertion';
+import {
+  assertions,
+  generators,
+  issueCloned
+} from 'data-integrity-test-suite-assertion';
+import {getMultiKey} from '../vc-generator/key-gen.js';
 
 export function assertConformance({
   verifiers,
@@ -39,19 +44,45 @@ export function assertConformance({
         it('Conforming processors MUST produce errors when non-conforming ' +
         'documents are consumed.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
-          await assertions.verificationFail({
-            verifier,
-            credential: {},
-            reason: 'Should '
-          });
+          for(const [key, credential] of credentials) {
+            await assertions.verificationFail({
+              verifier,
+              credential,
+              reason: `Should not verify VC with ${key}`
+            });
+          }
         });
       });
     }
   });
 }
-async function _setup({}) {
-  // not bs58 encoded verificationMethod
-  // type is not DataIntegrityProof
-  // invalid cryptosuite name
+async function _setup({
+  credential,
+  suiteName,
+  keyType,
+  cryptosuite,
+  mandatoryPointers,
+  selectivePointers
+}) {
+  const {
+    invalidProofType,
+    invalidVm,
+    invalidCryptosuite
+  } = generators?.mandatory;
+  const credentials = new Map();
+  const keyPair = await getMultiKey({keyType});
+  const signer = keyPair.signer();
+  // not bs58 encoded verificationMethod via invalidVm
+  // type is not DataIntegrityProof invalidType
+  // invalid cryptosuite name invalidCryptosuite
+  credentials.set('invalidCryptosuite', await issueCloned(invalidCryptosuite({
 
+  })));
+  credentials.set('invalidVerificationMethod', await issueCloned(invalidVm({
+
+  })));
+  credentials.set('invalidProofType', await issueCloned(invalidProofType({
+
+  })));
+  return credentials;
 }

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -3,16 +3,38 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-describe('Conformance', function() {
-  beforeEach(function() {
+export function assertConformance({
+  issuers,
+  verifiers,
+  suiteName,
+  keyType,
+  vcVersion,
+  credentials
+}) {
+  describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
+    this.matrix = true;
+    this.report = true;
+    this.implemented = [...issuers];
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Implementation';
+    for(const [name, {endpoints}] of issuers) {
+      describe(`${name} ${keyType}`, function() {
+        beforeEach(function() {
+          this.currentTest.cell = {
+            rowId: this.currentTest.title,
+            columnId: `${name} ${keyType}`
+          };
+        });
+        it('Specifically, all relevant normative statements in Sections 2. Data ' +
+        'Model and 3. Algorithms of this document MUST be enforced.', function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
+        });
+        it('Conforming processors MUST produce errors when non-conforming ' +
+        'documents are consumed.', function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
+        });
+      });
+    }
+  });
+}
 
-  });
-  it('Specifically, all relevant normative statements in Sections 2. Data ' +
-  'Model and 3. Algorithms of this document MUST be enforced.', function() {
-    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
-  });
-  it('Conforming processors MUST produce errors when non-conforming ' +
-  'documents are consumed.', function() {
-    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
-  });
-});

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -14,7 +14,7 @@ import {getSuite} from '../vc-generator/cryptosuites.js';
 export function conformanceSuite({
   verifiers,
   suiteName,
-  keyType,
+  keyTypes,
   vcVersion,
   credential,
   mandatoryPointers,
@@ -24,52 +24,58 @@ export function conformanceSuite({
   return describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...verifiers];
+    this.implemented = [];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    let credentials = new Map();
+    const credentials = new Map(keyTypes.map(kt => [kt, null]));
     before(async function() {
-      credentials = await setup({
-        credential,
-        mandatoryPointers,
-        selectivePointers,
-        suiteName,
-        keyType
-      });
+      for(const keyType of keyTypes) {
+        credentials.set(keyType, await setup({
+          credential,
+          mandatoryPointers,
+          selectivePointers,
+          suiteName,
+          keyType
+        }));
+      }
     });
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;
-      describe(`${name}: ${keyType}`, function() {
-        beforeEach(function() {
-          this.currentTest.cell = {
-            rowId: this.currentTest.title,
-            columnId: this.currentTest.parent.title
-          };
+      for(const keyType of keyTypes) {
+      // add implementer name and keyType to test report
+        this.implemented.push(`${name}: ${keyType}`);
+        describe(`${name}: ${keyType}`, function() {
+          beforeEach(function() {
+            this.currentTest.cell = {
+              rowId: this.currentTest.title,
+              columnId: this.currentTest.parent.title
+            };
+          });
+          it('Specifically, all relevant normative statements in Sections 2. ' +
+          'Data Model and 3. Algorithms of this document MUST be enforced.',
+          async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
+            for(const [key, credential] of credentials.get(keyType)) {
+              await assertions.verificationFail({
+                verifier,
+                credential,
+                reason: `Should not verify VC with ${key}`
+              });
+            }
+          });
+          it('Conforming processors MUST produce errors when non-conforming ' +
+          'documents are consumed.', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
+            for(const [key, credential] of credentials.get(keyType)) {
+              await assertions.verificationFail({
+                verifier,
+                credential,
+                reason: `Should not verify VC with ${key}`
+              });
+            }
+          });
         });
-        it('Specifically, all relevant normative statements in Sections 2. ' +
-        'Data Model and 3. Algorithms of this document MUST be enforced.',
-        async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Specifically%2C%20all%20relevant%20normative%20statements%20in%20Sections%202.%20Data%20Model%20and%203.%20Algorithms%20of%20this%20document%20MUST%20be%20enforced.';
-          for(const [key, credential] of credentials) {
-            await assertions.verificationFail({
-              verifier,
-              credential,
-              reason: `Should not verify VC with ${key}`
-            });
-          }
-        });
-        it('Conforming processors MUST produce errors when non-conforming ' +
-        'documents are consumed.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#:~:text=Conforming%20processors%20MUST%20produce%20errors%20when%20non%2Dconforming%20documents%20are%20consumed.';
-          for(const [key, credential] of credentials) {
-            await assertions.verificationFail({
-              verifier,
-              credential,
-              reason: `Should not verify VC with ${key}`
-            });
-          }
-        });
-      });
+      }
     }
   });
 }

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -21,7 +21,7 @@ export function conformanceSuite({
   selectivePointers,
   setup = _setup
 }) {
-  describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
+  return describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
     this.implemented = [...verifiers];

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -11,12 +11,14 @@ import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {getMultiKey} from '../vc-generator/key-gen.js';
 import {getSuite} from '../vc-generator/cryptosuites.js';
 
-export function assertConformance({
+export function conformanceSuite({
   verifiers,
   suiteName,
   keyType,
   vcVersion,
   credential,
+  mandatoryPointers,
+  selectivePointers,
   setup = _setup
 }) {
   describe(`${suiteName} - Conformance - VC ${vcVersion}`, function() {
@@ -27,7 +29,13 @@ export function assertConformance({
     this.columnLabel = 'Implementation';
     let credentials = new Map();
     before(async function() {
-      credentials = await setup({credential, suiteName, keyType});
+      credentials = await setup({
+        credential,
+        mandatoryPointers,
+        selectivePointers,
+        suiteName,
+        keyType
+      });
     });
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -6,6 +6,7 @@ import {createInitialVc, endpointCheck} from '../helpers.js';
 import {
   assertions,
 } from 'data-integrity-test-suite-assertion';
+import {didResolver} from '../didResolver.js';
 import {expect} from 'chai';
 
 export function dataModelSuite({
@@ -70,9 +71,12 @@ export function dataModelSuite({
           for(const proof of proofs) {
             expect(proof.verificationMethod).to.exist;
             expect(proof.verificationMethod).to.be.a('string');
+            const didDoc = await didResolver({url: proof.verificationMethod});
+            expect(didDoc).to.be.an('object');
+            expect(didDoc.publicKeyMultibase).to.be.a('string');
             expect(
-              assertions.shouldBeBs58(proof.verificationMethod),
-              'Expected "proof.verificationMethod" to be Base58 encoded'
+              assertions.shouldBeBs58(didDoc.publicKeyMultibase),
+              'Expected "publicKeyMultibase" to be Base58 encoded'
             ).to.be.true;
           }
         });
@@ -83,9 +87,12 @@ export function dataModelSuite({
             for(const proof of proofs) {
               expect(proof.verificationMethod).to.exist;
               expect(proof.verificationMethod).to.be.a('string');
+              const didDoc = await didResolver({url: proof.verificationMethod});
+              expect(didDoc).to.be.an('object');
+              expect(didDoc.publicKeyMultibase).to.be.a('string');
               expect(
-                assertions.shouldBeBs58(proof.verificationMethod),
-                'Expected "proof.verificationMethod" to be Base58 encoded'
+                assertions.shouldBeBs58(didDoc.publicKeyMultibase),
+                'Expected "publicKeyMultibase" to be Base58 encoded'
               ).to.be.true;
             }
           });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -12,7 +12,7 @@ import {expect} from 'chai';
 export function dataModelSuite({
   issuers,
   suiteName,
-  keyType,
+  keyTypes,
   vcVersion,
   credential,
   mandatoryPointers
@@ -20,103 +20,111 @@ export function dataModelSuite({
   return describe(`${suiteName} - Data Model - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...issuers];
+    this.implemented = [];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints}] of issuers) {
-      const [issuer] = endpoints;
-      // does the endpoint support this test?
-      if(!endpointCheck({endpoint: issuer, keyType, vcVersion})) {
-        continue;
-      }
-      describe(`${name}: ${keyType}`, function() {
-        let securedCredential = null;
-        let proofs = [];
-        before(async function() {
-          securedCredential = await createInitialVc({
-            issuer,
-            vcVersion,
-            vc: credential,
-            mandatoryPointers
-          });
-          if(securedCredential) {
-            proofs = Array.isArray(securedCredential.proof) ?
-              securedCredential?.proof : [securedCredential?.proof];
-            // only test proofs that match the relevant cryptosuite
-            proofs = proofs.filter(p => p?.cryptosuite === suiteName);
+      for(const keyType of keyTypes) {
+        for(const issuer of endpoints) {
+        // does the endpoint support this test?
+          if(!endpointCheck({endpoint: issuer, keyType, vcVersion})) {
+            continue;
           }
-        });
-        beforeEach(function() {
-          this.currentTest.cell = {
-            rowId: this.currentTest.title,
-            columnId: this.currentTest.parent.title
-          };
-        });
-        function assertBefore() {
-          expect(
-            securedCredential,
-            `Expected issuer ${name}: ${keyType} to issue a VC.`
-          ).to.exist;
-          expect(
-            securedCredential,
-            'Expected VC to be an object.'
-          ).to.be.an('object');
-        }
-        it('The publicKeyMultibase value of the verification method MUST ' +
-          'start with the base-58-btc prefix (z), as defined in the ' +
-          'Multibase section of Controller Documents 1.0. ',
-        async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#data-model:~:text=The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix%20(z)%2C%20as%20defined%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
-          assertBefore();
-          for(const proof of proofs) {
-            expect(proof.verificationMethod).to.exist;
-            expect(proof.verificationMethod).to.be.a('string');
-            const didDoc = await didResolver({url: proof.verificationMethod});
-            expect(didDoc).to.be.an('object');
-            expect(didDoc.publicKeyMultibase).to.be.a('string');
-            expect(
-              assertions.shouldBeBs58(didDoc.publicKeyMultibase),
-              'Expected "publicKeyMultibase" to be Base58 encoded.'
-            ).to.be.true;
-          }
-        });
-        it('Any other encoding MUST NOT be allowed. (verificationMethod)',
-          async function() {
-            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey';
-            assertBefore();
-            for(const proof of proofs) {
-              expect(proof.verificationMethod).to.exist;
-              expect(proof.verificationMethod).to.be.a('string');
-              const didDoc = await didResolver({url: proof.verificationMethod});
-              expect(didDoc).to.be.an('object');
-              expect(didDoc.publicKeyMultibase).to.be.a('string');
+          // add implementer name and keyType to test report
+          this.implemented.push(`${name}: ${keyType}`);
+          describe(`${name}: ${keyType}`, function() {
+            let securedCredential = null;
+            let proofs = [];
+            before(async function() {
+              securedCredential = await createInitialVc({
+                issuer,
+                vcVersion,
+                vc: credential,
+                mandatoryPointers
+              });
+              if(securedCredential) {
+                proofs = Array.isArray(securedCredential.proof) ?
+                  securedCredential?.proof : [securedCredential?.proof];
+                // only test proofs that match the relevant cryptosuite
+                proofs = proofs.filter(p => p?.cryptosuite === suiteName);
+              }
+            });
+            beforeEach(function() {
+              this.currentTest.cell = {
+                rowId: this.currentTest.title,
+                columnId: this.currentTest.parent.title
+              };
+            });
+            function assertBefore() {
               expect(
-                assertions.shouldBeBs58(didDoc.publicKeyMultibase),
-                'Expected "publicKeyMultibase" to be Base58 encoded.'
-              ).to.be.true;
+                securedCredential,
+                `Expected issuer ${name}: ${keyType} to issue a VC.`
+              ).to.exist;
+              expect(
+                securedCredential,
+                'Expected VC to be an object.'
+              ).to.be.an('object');
             }
+            it('The publicKeyMultibase value of the verification method MUST ' +
+              'start with the base-58-btc prefix (z), as defined in the ' +
+              'Multibase section of Controller Documents 1.0. ',
+            async function() {
+              this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#data-model:~:text=The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix%20(z)%2C%20as%20defined%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
+              assertBefore();
+              for(const proof of proofs) {
+                expect(proof.verificationMethod).to.exist;
+                expect(proof.verificationMethod).to.be.a('string');
+                const didDoc = await didResolver({
+                  url: proof.verificationMethod});
+                expect(didDoc).to.be.an('object');
+                expect(didDoc.publicKeyMultibase).to.be.a('string');
+                expect(
+                  assertions.shouldBeBs58(didDoc.publicKeyMultibase),
+                  'Expected "publicKeyMultibase" to be Base58 encoded.'
+                ).to.be.true;
+              }
+            });
+            it('Any other encoding MUST NOT be allowed. (verificationMethod)',
+              async function() {
+                this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey';
+                assertBefore();
+                for(const proof of proofs) {
+                  expect(proof.verificationMethod).to.exist;
+                  expect(proof.verificationMethod).to.be.a('string');
+                  const didDoc = await didResolver({
+                    url: proof.verificationMethod});
+                  expect(didDoc).to.be.an('object');
+                  expect(didDoc.publicKeyMultibase).to.be.a('string');
+                  expect(
+                    assertions.shouldBeBs58(didDoc.publicKeyMultibase),
+                    'Expected "publicKeyMultibase" to be Base58 encoded.'
+                  ).to.be.true;
+                }
+              });
+            it('The type property MUST be DataIntegrityProof.',
+              async function() {
+                this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
+                assertBefore();
+                for(const proof of proofs) {
+                  expect(proof.type).to.exist;
+                  expect(proof.type).to.be.a('string');
+                  expect(proof.type).to.equal('DataIntegrityProof');
+                }
+              });
+            it('The cryptosuite property MUST be ecdsa-rdfc-2019, ' +
+              'ecdsa-jcs-2019, or ecdsa-sd-2023.', async function() {
+              this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.';
+              assertBefore();
+              for(const proof of proofs) {
+                expect(proof.cryptosuite).to.exist;
+                expect(proof.cryptosuite).to.be.a('string');
+                expect(proof.cryptosuite).to.be.oneOf(
+                  ['ecdsa-rdfc-2019', 'edcsa-jcs-2019', 'ecdsa-sd-2023']);
+              }
+            });
           });
-        it('The type property MUST be DataIntegrityProof.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
-          assertBefore();
-          for(const proof of proofs) {
-            expect(proof.type).to.exist;
-            expect(proof.type).to.be.a('string');
-            expect(proof.type).to.equal('DataIntegrityProof');
-          }
-        });
-        it('The cryptosuite property MUST be ecdsa-rdfc-2019, ' +
-          'ecdsa-jcs-2019, or ecdsa-sd-2023.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.';
-          assertBefore();
-          for(const proof of proofs) {
-            expect(proof.cryptosuite).to.exist;
-            expect(proof.cryptosuite).to.be.a('string');
-            expect(proof.cryptosuite).to.be.oneOf(
-              ['ecdsa-rdfc-2019', 'edcsa-jcs-2019', 'ecdsa-sd-2023']);
-          }
-        });
-      });
+        }
+      }
     }
   });
 }

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -55,11 +55,11 @@ export function dataModelSuite({
         function assertBefore() {
           expect(
             securedCredential,
-            `Expected issuer ${name}: ${keyType} to issue a VC`
+            `Expected issuer ${name}: ${keyType} to issue a VC.`
           ).to.exist;
           expect(
             securedCredential,
-            'Expected VC to be an object'
+            'Expected VC to be an object.'
           ).to.be.an('object');
         }
         it('The publicKeyMultibase value of the verification method MUST ' +

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -63,11 +63,9 @@ export function dataModelSuite({
         }
         it('The publicKeyMultibase value of the verification method MUST ' +
           'start with the base-58-btc prefix (z), as defined in the ' +
-          'Multibase section of Controller Documents 1.0. A ' +
-          'Multibase-encoded Ed25519 256-bit public key value follows, as ' +
-          'defined in the Multikey section of Controller Documents 1.0.',
+          'Multibase section of Controller Documents 1.0. A ',
         async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=in%20this%20specification.-,The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix,-(z)%2C%20as';
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#data-model:~:text=The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix%20(z)%2C%20as%20defined%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
           assertBefore();
           for(const proof of proofs) {
             expect(proof.verificationMethod).to.exist;
@@ -80,7 +78,7 @@ export function dataModelSuite({
         });
         it('Any other encoding MUST NOT be allowed. (verificationMethod)',
           async function() {
-            this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=of%20Controller%20Documents%201.0.-,Any%20other%20encoding%20MUST%20NOT%20be%20allowed.,-Developers%20are%20advised%20to%20not';
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey';
             assertBefore();
             for(const proof of proofs) {
               expect(proof.verificationMethod).to.exist;
@@ -92,7 +90,7 @@ export function dataModelSuite({
             }
           });
         it('The type property MUST be DataIntegrityProof.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
           assertBefore();
           for(const proof of proofs) {
             expect(proof.type).to.exist;
@@ -100,30 +98,15 @@ export function dataModelSuite({
             expect(proof.type).to.equal('DataIntegrityProof');
           }
         });
-        it('The cryptosuite property of the proof MUST be eddsa-rdfc-2022 or ' +
-          'eddsa-jcs-2022.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20cryptosuite%20property%20of%20the%20proof%20MUST%20be%20eddsa%2Drdfc%2D2022%20or%20eddsa%2Djcs%2D2022.';
+        it('The cryptosuite property MUST be ecdsa-rdfc-2019, ' +
+          'ecdsa-jcs-2019, or ecdsa-sd-2023.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#multikey:~:text=The%20cryptosuite%20property%20MUST%20be%20ecdsa%2Drdfc%2D2019%2C%20ecdsa%2Djcs%2D2019%2C%20or%20ecdsa%2Dsd%2D2023.';
           assertBefore();
           for(const proof of proofs) {
             expect(proof.cryptosuite).to.exist;
             expect(proof.cryptosuite).to.be.a('string');
             expect(proof.cryptosuite).to.be.oneOf(
-              ['eddsa-rdfc-2022', 'eddsa-jcs-2022']);
-          }
-        });
-        it('The proofValue property of the proof MUST be a detached EdDSA ' +
-          'signature produced according to [RFC8032], encoded using the ' +
-          'base-58-btc header and alphabet as described in the Multibase ' +
-          'section of Controller Documents 1.0.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20detached%20EdDSA%20signature%20produced%20according%20to%20%5BRFC8032%5D%2C%20encoded%20using%20the%20base%2D58%2Dbtc%20header%20and%20alphabet%20as%20described%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
-          assertBefore();
-          for(const proof of proofs) {
-            expect(proof.proofValue).to.exist;
-            expect(proof.proofValue).to.be.a('string');
-            expect(
-              assertions.shouldBeBs58(proof.proofValue),
-              'Expected "proof.proofValue" to be Base58 encoded'
-            ).to.be.true;
+              ['ecdsa-rdfc-2019', 'edcsa-jcs-2019', 'ecdsa-sd-2023']);
           }
         });
       });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -107,7 +107,7 @@ export function dataModelSuite({
           for(const proof of proofs) {
             expect(proof.cryptosuite).to.exist;
             expect(proof.cryptosuite).to.be.a('string');
-            expect(proof.cryptosuite).to.oneOf(
+            expect(proof.cryptosuite).to.be.oneOf(
               ['eddsa-rdfc-2022', 'eddsa-jcs-2022']);
           }
         });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -39,10 +39,10 @@ export function dataModelSuite({
             mandatoryPointers
           });
           if(securedCredential) {
-            proofs = Array.isArray(securedCredential.proofs) ?
-              securedCredential?.proofs : [securedCredential?.proofs];
+            proofs = Array.isArray(securedCredential.proof) ?
+              securedCredential?.proof : [securedCredential?.proof];
             // only test proofs that match the relevant cryptosuite
-            proofs.filter(p => p.cryptosuite === suiteName);
+            proofs = proofs.filter(p => p?.cryptosuite === suiteName);
           }
         });
         beforeEach(function() {

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -2,9 +2,11 @@
  * Copyright 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+import {createInitialVc, endpointCheck} from '../helpers.js';
 import {
   assertions,
 } from 'data-integrity-test-suite-assertion';
+import {expect} from 'chai';
 
 export function dataModelSuite({
   issuers,
@@ -12,8 +14,7 @@ export function dataModelSuite({
   keyType,
   vcVersion,
   credential,
-  mandatoryPointers,
-  selectivePointers,
+  mandatoryPointers
 }) {
   describe(`${suiteName} - Data Model - VC ${vcVersion}`, function() {
     this.matrix = true;
@@ -23,11 +24,19 @@ export function dataModelSuite({
     this.columnLabel = 'Implementation';
     for(const [name, {endpoints}] of issuers) {
       const [issuer] = endpoints;
+      // does the endpoint support this test?
+      if(!endpointCheck({endpoint: issuer, keyType, vcVersion})) {
+        continue;
+      }
       describe(`${name}: ${keyType}`, function() {
         let securedCredential = null;
-        let issuerError = null;
-        before(async function(){
-
+        before(async function() {
+          securedCredential = await createInitialVc({
+            issuer,
+            vcVersion,
+            vc: credential,
+            mandatoryPointers
+          });
         });
         beforeEach(function() {
           this.currentTest.cell = {
@@ -35,6 +44,12 @@ export function dataModelSuite({
             columnId: this.currentTest.parent.title
           };
         });
+        function assertBefore() {
+          expect(
+            securedCredential,
+            `Expected issuer ${name}: ${keyType} to issue a VC`
+          ).to.exist;
+        }
         it('The publicKeyMultibase value of the verification method MUST ' +
           'start with the base-58-btc prefix (z), as defined in the ' +
           'Multibase section of Controller Documents 1.0. A ' +
@@ -42,23 +57,28 @@ export function dataModelSuite({
           'defined in the Multikey section of Controller Documents 1.0.',
         async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=in%20this%20specification.-,The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix,-(z)%2C%20as';
+          assertBefore();
         });
         it('Any other encoding MUST NOT be allowed. (verificationMethod)',
           async function() {
             this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=of%20Controller%20Documents%201.0.-,Any%20other%20encoding%20MUST%20NOT%20be%20allowed.,-Developers%20are%20advised%20to%20not';
+            assertBefore();
           });
         it('The type property MUST be DataIntegrityProof.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
+          assertBefore();
         });
         it('The cryptosuite property of the proof MUST be eddsa-rdfc-2022 or ' +
           'eddsa-jcs-2022.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20cryptosuite%20property%20of%20the%20proof%20MUST%20be%20eddsa%2Drdfc%2D2022%20or%20eddsa%2Djcs%2D2022.';
+          assertBefore();
         });
         it('The proofValue property of the proof MUST be a detached EdDSA ' +
           'signature produced according to [RFC8032], encoded using the ' +
           'base-58-btc header and alphabet as described in the Multibase ' +
           'section of Controller Documents 1.0.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20detached%20EdDSA%20signature%20produced%20according%20to%20%5BRFC8032%5D%2C%20encoded%20using%20the%20base%2D58%2Dbtc%20header%20and%20alphabet%20as%20described%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
+          assertBefore();
 
         });
       });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -92,7 +92,7 @@ export function dataModelSuite({
               expect(didDoc.publicKeyMultibase).to.be.a('string');
               expect(
                 assertions.shouldBeBs58(didDoc.publicKeyMultibase),
-                'Expected "publicKeyMultibase" to be Base58 encoded'
+                'Expected "publicKeyMultibase" to be Base58 encoded.'
               ).to.be.true;
             }
           });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -76,7 +76,7 @@ export function dataModelSuite({
             expect(didDoc.publicKeyMultibase).to.be.a('string');
             expect(
               assertions.shouldBeBs58(didDoc.publicKeyMultibase),
-              'Expected "publicKeyMultibase" to be Base58 encoded'
+              'Expected "publicKeyMultibase" to be Base58 encoded.'
             ).to.be.true;
           }
         });

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {
+  assertions,
+} from 'data-integrity-test-suite-assertion';
+
+export function dataModelSuite({
+  issuers,
+  suiteName,
+  keyType,
+  vcVersion,
+  credential,
+  mandatoryPointers,
+  selectivePointers,
+}) {
+  describe(`${suiteName} - Data Model - VC ${vcVersion}`, function() {
+    this.matrix = true;
+    this.report = true;
+    this.implemented = [...issuers];
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Implementation';
+    for(const [name, {endpoints}] of issuers) {
+      const [issuer] = endpoints;
+      describe(`${name}: ${keyType}`, function() {
+        let securedCredential = null;
+        let issuerError = null;
+        before(async function(){
+
+        });
+        beforeEach(function() {
+          this.currentTest.cell = {
+            rowId: this.currentTest.title,
+            columnId: this.currentTest.parent.title
+          };
+        });
+        it('The publicKeyMultibase value of the verification method MUST ' +
+          'start with the base-58-btc prefix (z), as defined in the ' +
+          'Multibase section of Controller Documents 1.0. A ' +
+          'Multibase-encoded Ed25519 256-bit public key value follows, as ' +
+          'defined in the Multikey section of Controller Documents 1.0.',
+        async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=in%20this%20specification.-,The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix,-(z)%2C%20as';
+        });
+        it('Any other encoding MUST NOT be allowed. (verificationMethod)',
+          async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=of%20Controller%20Documents%201.0.-,Any%20other%20encoding%20MUST%20NOT%20be%20allowed.,-Developers%20are%20advised%20to%20not';
+          });
+        it('The type property MUST be DataIntegrityProof.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
+        });
+        it('The cryptosuite property of the proof MUST be eddsa-rdfc-2022 or ' +
+          'eddsa-jcs-2022.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20cryptosuite%20property%20of%20the%20proof%20MUST%20be%20eddsa%2Drdfc%2D2022%20or%20eddsa%2Djcs%2D2022.';
+        });
+        it('The proofValue property of the proof MUST be a detached EdDSA ' +
+          'signature produced according to [RFC8032], encoded using the ' +
+          'base-58-btc header and alphabet as described in the Multibase ' +
+          'section of Controller Documents 1.0.', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20detached%20EdDSA%20signature%20produced%20according%20to%20%5BRFC8032%5D%2C%20encoded%20using%20the%20base%2D58%2Dbtc%20header%20and%20alphabet%20as%20described%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
+
+        });
+      });
+    }
+  });
+}

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -82,15 +82,34 @@ export function dataModelSuite({
           async function() {
             this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=of%20Controller%20Documents%201.0.-,Any%20other%20encoding%20MUST%20NOT%20be%20allowed.,-Developers%20are%20advised%20to%20not';
             assertBefore();
+            for(const proof of proofs) {
+              expect(proof.verificationMethod).to.exist;
+              expect(proof.verificationMethod).to.be.a('string');
+              expect(
+                assertions.shouldBeBs58(proof.verificationMethod),
+                'Expected "proof.verificationMethod" to be Base58 encoded'
+              ).to.be.true;
+            }
           });
         it('The type property MUST be DataIntegrityProof.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20type%20property%20MUST%20be%20DataIntegrityProof.';
           assertBefore();
+          for(const proof of proofs) {
+            expect(proof.type).to.exist;
+            expect(proof.type).to.be.a('string');
+            expect(proof.type).to.equal('DataIntegrityProof');
+          }
         });
         it('The cryptosuite property of the proof MUST be eddsa-rdfc-2022 or ' +
           'eddsa-jcs-2022.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20cryptosuite%20property%20of%20the%20proof%20MUST%20be%20eddsa%2Drdfc%2D2022%20or%20eddsa%2Djcs%2D2022.';
           assertBefore();
+          for(const proof of proofs) {
+            expect(proof.cryptosuite).to.exist;
+            expect(proof.cryptosuite).to.be.a('string');
+            expect(proof.cryptosuite).to.oneOf(
+              ['eddsa-rdfc-2022', 'eddsa-jcs-2022']);
+          }
         });
         it('The proofValue property of the proof MUST be a detached EdDSA ' +
           'signature produced according to [RFC8032], encoded using the ' +
@@ -98,7 +117,14 @@ export function dataModelSuite({
           'section of Controller Documents 1.0.', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-eddsa/#data-model:~:text=The%20proofValue%20property%20of%20the%20proof%20MUST%20be%20a%20detached%20EdDSA%20signature%20produced%20according%20to%20%5BRFC8032%5D%2C%20encoded%20using%20the%20base%2D58%2Dbtc%20header%20and%20alphabet%20as%20described%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
           assertBefore();
-
+          for(const proof of proofs) {
+            expect(proof.proofValue).to.exist;
+            expect(proof.proofValue).to.be.a('string');
+            expect(
+              assertions.shouldBeBs58(proof.proofValue),
+              'Expected "proof.proofValue" to be Base58 encoded'
+            ).to.be.true;
+          }
         });
       });
     }

--- a/tests/suites/data-model.js
+++ b/tests/suites/data-model.js
@@ -64,7 +64,7 @@ export function dataModelSuite({
         }
         it('The publicKeyMultibase value of the verification method MUST ' +
           'start with the base-58-btc prefix (z), as defined in the ' +
-          'Multibase section of Controller Documents 1.0. A ',
+          'Multibase section of Controller Documents 1.0. ',
         async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#data-model:~:text=The%20publicKeyMultibase%20value%20of%20the%20verification%20method%20MUST%20start%20with%20the%20base%2D58%2Dbtc%20prefix%20(z)%2C%20as%20defined%20in%20the%20Multibase%20section%20of%20Controller%20Documents%201.0.';
           assertBefore();


### PR DESCRIPTION
1. Adds two normative statements from Conformance section
2. Adds 3 minimal negative tests for those statements
3. Reuses code from the data-integrity-test-suite-assertion
4. Adds a new `suites` dir which contains functions that create parametertized suites
5. Contains fixes from https://github.com/w3c/vc-di-ecdsa-test-suite/pull/95

This PR is intended to be the final stop for all of the ecdsa related rewrites in the current sprint.