### PR TITLE
Add algorithm suites (2 -> 1)

### DIFF
--- a/config/runner.json
+++ b/config/runner.json
@@ -8,7 +8,7 @@
         "P-384": 96
       },
       "interop": {
-        "vcVersion": "1.1"
+        "vcVersion": "2.0"
       }
     },
     "ecdsa-sd-2023": {

--- a/config/runner.json
+++ b/config/runner.json
@@ -11,6 +11,16 @@
         "vcVersion": "2.0"
       }
     },
+    "ecdsa-jcs-2019": {
+      "tags": ["ecdsa-jcs-2019"],
+      "proofLengths": {
+        "P-256": 64,
+        "P-384": 96
+      },
+      "interop": {
+        "vcVersion": "2.0"
+      }
+    },
     "ecdsa-sd-2023": {
       "tags": ["ecdsa-sd-2023"],
       "interop": {

--- a/tests/90-algorithms-jcs.js
+++ b/tests/90-algorithms-jcs.js
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {ecdsaJcs2019Algorithms} from './suites/algorithms-jcs.js';
+
+ecdsaJcs2019Algorithms();

--- a/tests/90-algorithms.js
+++ b/tests/90-algorithms.js
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {ecdsaRdfc2019Algorithms} from './suites/algorithms.js';
+import {endpoints} from 'vc-test-suite-implementations';
+import {getSuiteConfig} from './test-config.js';
+
+const cryptosuites = [
+  'ecdsa-rdfc-2019',
+];
+
+for(const suiteName of cryptosuites) {
+  const {tags, credentials, vectors} = getSuiteConfig(suiteName);
+  const {match: verifiers} = endpoints.filterByTag({
+    tags: [...tags],
+    property: 'verifiers'
+  });
+  for(const vcVersion of vectors.vcTypes) {
+    const {
+      document,
+      mandatoryPointers,
+      selectivePointers
+    } = credentials.create[vcVersion];
+    for(const keyType of vectors.keyTypes) {
+      ecdsaRdfc2019Algorithms({
+        verifiers,
+        suiteName,
+        keyType,
+        vcVersion,
+        credential: document,
+        mandatoryPointers,
+        selectivePointers
+      });
+    }
+  }
+}

--- a/tests/90-algorithms.js
+++ b/tests/90-algorithms.js
@@ -22,16 +22,14 @@ for(const suiteName of cryptosuites) {
       mandatoryPointers,
       selectivePointers
     } = credentials.create[vcVersion];
-    for(const keyType of vectors.keyTypes) {
-      ecdsaRdfc2019Algorithms({
-        verifiers,
-        suiteName,
-        keyType,
-        vcVersion,
-        credential: document,
-        mandatoryPointers,
-        selectivePointers
-      });
-    }
+    ecdsaRdfc2019Algorithms({
+      verifiers,
+      suiteName,
+      keyTypes: vectors.keyTypes,
+      vcVersion,
+      credential: document,
+      mandatoryPointers,
+      selectivePointers
+    });
   }
 }

--- a/tests/90-algorithms.js
+++ b/tests/90-algorithms.js
@@ -2,7 +2,10 @@
  * Copyright 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-import {ecdsaRdfc2019Algorithms} from './suites/algorithms.js';
+import {
+  commonAlgorithms,
+  ecdsaRdfc2019Algorithms
+} from './suites/algorithms.js';
 import {endpoints} from 'vc-test-suite-implementations';
 import {getSuiteConfig} from './test-config.js';
 
@@ -23,6 +26,15 @@ for(const suiteName of cryptosuites) {
       selectivePointers
     } = credentials.create[vcVersion];
     ecdsaRdfc2019Algorithms({
+      verifiers,
+      suiteName,
+      keyTypes: vectors.keyTypes,
+      vcVersion,
+      credential: document,
+      mandatoryPointers,
+      selectivePointers
+    });
+    commonAlgorithms({
       verifiers,
       suiteName,
       keyTypes: vectors.keyTypes,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -282,8 +282,8 @@ export function setupRow() {
 }
 
 export function getProofs(issuedVc) {
-  // if the implementation failed to issue a VC or to sign the VC, return
-  // an empty array
+  // if the implementation failed to issue a VC or to sign the VC,
+  // return an empty array
   if(!issuedVc?.proof) {
     return [];
   }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -91,7 +91,7 @@ export const createDisclosedVc = async ({
 export const endpointCheck = ({endpoint, vcVersion, keyType}) => {
   const {
     supportedEcdsaKeyTypes,
-    // assume support for vc 1.1
+    // assume support for vc 2.0
     supports = {vc: ['2.0']}
   } = endpoint.settings;
   // if an issuer does not support the current keyType skip it

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -92,7 +92,7 @@ export const endpointCheck = ({endpoint, vcVersion, keyType}) => {
   const {
     supportedEcdsaKeyTypes,
     // assume support for vc 1.1
-    supports = {vc: ['1.1']}
+    supports = {vc: ['2.0']}
   } = endpoint.settings;
   // if an issuer does not support the current keyType skip it
   const keyTypes = supportedEcdsaKeyTypes || supports?.keyTypes;

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -210,12 +210,14 @@ export function getColumnNameForTestCategory(testCategory) {
   }
 }
 
-export function setupReportableTestSuite(runnerContext, name) {
+export function setupReportableTestSuite(
+  runnerContext,
+  name = 'Implementation'
+) {
   runnerContext.matrix = true;
   runnerContext.report = true;
   runnerContext.rowLabel = 'Test Name';
   runnerContext.columnLabel = name;
-
   runnerContext.implemented = [];
 }
 
@@ -231,16 +233,6 @@ export function isValidUtf8(string) {
 
 export function isValidDatetime(dateString) {
   return !isNaN(Date.parse(dateString));
-}
-
-export function setupMatrix(match) {
-  // this will tell the report
-  // to make an interop matrix with this suite
-  this.matrix = true;
-  this.report = true;
-  this.implemented = [...match.keys()];
-  this.rowLabel = 'Test Name';
-  this.columnLabel = 'Implementer';
 }
 
 export const config = JSON.parse(readFileSync('./config/runner.json'));

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -9,7 +9,7 @@ import {
   getProofs,
   isValidDatetime,
   isValidUtf8,
-  setupMatrix,
+  setupReportableTestSuite,
   setupRow
 } from '../helpers.js';
 import chai from 'chai';
@@ -20,7 +20,7 @@ export function ecdsaJcs2019Algorithms() {
   const {tags} = config.suites[
     cryptosuite
   ];
-  const {issuerMatch} = endpoints.filterByTag({
+  const {match: issuers} = endpoints.filterByTag({
     tags: [...tags],
     property: 'issuers'
   });
@@ -31,12 +31,12 @@ export function ecdsaJcs2019Algorithms() {
   const should = chai.should();
 
   describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
-    setupMatrix.call(this, issuerMatch);
+    setupReportableTestSuite(this);
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();
     });
-    for(const [columnId, {endpoints}] of issuerMatch) {
+    for(const [columnId, {endpoints}] of issuers) {
       describe(columnId, function() {
         const [issuer] = endpoints;
         let issuedVc;
@@ -99,8 +99,8 @@ export function ecdsaJcs2019Algorithms() {
               'Expected a cryptosuite identifier on the proof.');
             proof.type.should.equal('DataIntegrityProof',
               'Expected DataIntegrityProof type.');
-            proof.cryptosuite.should.equal('ecdsa-jcs-2022',
-              'Expected ecdsa-jcs-2022 cryptosuite.');
+            proof.cryptosuite.should.equal('ecdsa-jcs-2019',
+              'Expected ecdsa-jcs-2019 cryptosuite.');
           }
         });
       });
@@ -108,12 +108,12 @@ export function ecdsaJcs2019Algorithms() {
   });
 
   describe('ecdsa-jcs-2019 - Algorithms - Proof Configuration', function() {
-    setupMatrix.call(this, issuerMatch);
+    setupReportableTestSuite(this);
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();
     });
-    for(const [columnId, {endpoints}] of issuerMatch) {
+    for(const [columnId, {endpoints}] of issuers) {
       describe(columnId, function() {
         const [issuer] = endpoints;
         let issuedVc;
@@ -162,8 +162,8 @@ export function ecdsaJcs2019Algorithms() {
               'Expected a cryptosuite identifier on the proof.');
             proof.type.should.equal('DataIntegrityProof',
               'Expected DataIntegrityProof type.');
-            proof.cryptosuite.should.equal('ecdsa-jcs-2022',
-              'Expected ecdsa-jcs-2022 cryptosuite.');
+            proof.cryptosuite.should.equal('ecdsa-jcs-2019',
+              'Expected ecdsa-jcs-2019 cryptosuite.');
           }
         });
         it('If proofConfig.created is set and if the value is not a ' +
@@ -185,12 +185,12 @@ export function ecdsaJcs2019Algorithms() {
   });
 
   describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
-    setupMatrix.call(this, issuerMatch);
+    setupReportableTestSuite(this);
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();
     });
-    for(const [columnId, {endpoints}] of issuerMatch) {
+    for(const [columnId, {endpoints}] of issuers) {
       describe(columnId, function() {
         const [issuer] = endpoints;
         let issuedVc;

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -24,14 +24,11 @@ export function ecdsaJcs2019Algorithms() {
     tags: [...tags],
     property: 'issuers'
   });
-  // const {verifierMatch} = endpoints.filterByTag({
-  //   tags: [...tags],
-  //   property: 'verifiers'
-  // });
   const should = chai.should();
 
   describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
     setupReportableTestSuite(this);
+    this.implemented = [...issuers.keys()];
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();
@@ -109,6 +106,7 @@ export function ecdsaJcs2019Algorithms() {
 
   describe('ecdsa-jcs-2019 - Algorithms - Proof Configuration', function() {
     setupReportableTestSuite(this);
+    this.implemented = [...issuers.keys()];
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();
@@ -186,6 +184,7 @@ export function ecdsaJcs2019Algorithms() {
 
   describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
     setupReportableTestSuite(this);
+    this.implemented = [...issuers.keys()];
     let validCredential;
     before(async function() {
       validCredential = await createValidCredential();

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -15,6 +15,8 @@ import {
 import chai from 'chai';
 import {endpoints} from 'vc-test-suite-implementations';
 
+const should = chai.should();
+
 export function ecdsaJcs2019Algorithms() {
   const cryptosuite = 'ecdsa-jcs-2019';
   const {tags} = config.suites[
@@ -24,7 +26,6 @@ export function ecdsaJcs2019Algorithms() {
     tags: [...tags],
     property: 'issuers'
   });
-  const should = chai.should();
 
   describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
     setupReportableTestSuite(this);
@@ -55,6 +56,17 @@ export function ecdsaJcs2019Algorithms() {
           jcs2019Proofs.length.should.be.gte(1, 'Expected at least one ' +
                       'ecdsa-jcs-2019 cryptosuite.');
         };
+        it('The proof options MUST contain a type identifier for the ' +
+          'cryptographic suite (type) and MAY contain a cryptosuite ' +
+          'identifier (cryptosuite).',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-serialization-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of jcs2019Proofs) {
+            should.exist(proof.type,
+              'Expected a type identifier on the proof.');
+          }
+        });
         it('The transformation options MUST contain a type identifier ' +
           'for the cryptographic suite (type) and a cryptosuite identifier ' +
           '(cryptosuite).',
@@ -176,50 +188,6 @@ export function ecdsaJcs2019Algorithms() {
                 'Expected created value to be a valid datetime string.'
               );
             }
-          }
-        });
-      });
-    }
-  });
-
-  describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
-    setupReportableTestSuite(this);
-    this.implemented = [...issuers.keys()];
-    let validCredential;
-    before(async function() {
-      validCredential = await createValidCredential();
-    });
-    for(const [columnId, {endpoints}] of issuers) {
-      describe(columnId, function() {
-        const [issuer] = endpoints;
-        let issuedVc;
-        let proofs;
-        let jcs2019Proofs = [];
-        before(async function() {
-          issuedVc = await createInitialVc({issuer, vc: validCredential});
-          proofs = getProofs(issuedVc);
-          if(proofs?.length) {
-            jcs2019Proofs = proofs.filter(
-              proof => proof?.cryptosuite === cryptosuite);
-          }
-        });
-        beforeEach(setupRow);
-        const assertBefore = () => {
-          should.exist(issuedVc, 'Expected issuer to have issued a ' +
-                      'credential.');
-          should.exist(proofs, 'Expected credential to have a proof.');
-          jcs2019Proofs.length.should.be.gte(1, 'Expected at least one ' +
-                      'ecdsa-jcs-2019 cryptosuite.');
-        };
-        it('The proof options MUST contain a type identifier for the ' +
-          'cryptographic suite (type) and MAY contain a cryptosuite ' +
-          'identifier (cryptosuite).',
-        async function() {
-          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-serialization-ecdsa-jcs-2019';
-          assertBefore();
-          for(const proof of jcs2019Proofs) {
-            should.exist(proof.type,
-              'Expected a type identifier on the proof.');
           }
         });
       });

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -10,7 +10,7 @@ import {
   setupMatrix,
   setupRow
 } from '../helpers.js';
-import {isValidDatetime, isValidUtf8} from './helpers.js';
+import {isValidDatetime, isValidUtf8} from '../helpers.js';
 import chai from 'chai';
 import {endpoints} from 'vc-test-suite-implementations';
 

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -7,10 +7,11 @@ import {
   createInitialVc,
   createValidCredential,
   getProofs,
+  isValidDatetime,
+  isValidUtf8,
   setupMatrix,
   setupRow
 } from '../helpers.js';
-import {isValidDatetime, isValidUtf8} from '../helpers.js';
 import chai from 'chai';
 import {endpoints} from 'vc-test-suite-implementations';
 

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -1,0 +1,228 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+import {
+  config,
+  createInitialVc,
+  createValidCredential,
+  getProofs,
+  setupMatrix,
+  setupRow
+} from '../helpers.js';
+import {isValidDatetime, isValidUtf8} from './helpers.js';
+import chai from 'chai';
+import {endpoints} from 'vc-test-suite-implementations';
+
+export function ecdsaJcs2019Algorithms() {
+  const cryptosuite = 'ecdsa-jcs-2022';
+  const {tags} = config.suites[
+    cryptosuite
+  ];
+  const {issuerMatch} = endpoints.filterByTag({
+    tags: [...tags],
+    property: 'issuers'
+  });
+  // const {verifierMatch} = endpoints.filterByTag({
+  //   tags: [...tags],
+  //   property: 'verifiers'
+  // });
+  const should = chai.should();
+
+  describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
+    setupMatrix.call(this, issuerMatch);
+    let validCredential;
+    before(async function() {
+      validCredential = await createValidCredential();
+    });
+    for(const [columnId, {endpoints}] of issuerMatch) {
+      describe(columnId, function() {
+        const [issuer] = endpoints;
+        let issuedVc;
+        let proofs;
+        let ecdsa2022Proofs = [];
+        before(async function() {
+          issuedVc = await createInitialVc({issuer, vc: validCredential});
+          proofs = getProofs(issuedVc);
+          if(proofs?.length) {
+            ecdsa2022Proofs = proofs.filter(
+              proof => proof?.cryptosuite === cryptosuite);
+          }
+        });
+        beforeEach(setupRow);
+        const assertBefore = () => {
+          should.exist(issuedVc, 'Expected issuer to have issued a ' +
+                      'credential.');
+          should.exist(proofs, 'Expected credential to have a proof.');
+          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+                      'ecdsa-jcs-2019 cryptosuite.');
+        };
+        it('The transformation options MUST contain a type identifier ' +
+          'for the cryptographic suite (type) and a cryptosuite identifier ' +
+          '(cryptosuite).',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof.type, 'Expected a type identifier on ' +
+                              'the proof.');
+            should.exist(proof.cryptosuite,
+              'Expected a cryptosuite identifier on the proof.');
+          }
+        });
+        it('Whenever this algorithm encodes strings, ' +
+          'it MUST use UTF-8 encoding.',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof?.proofValue,
+              'Expected proofValue to exist.');
+            isValidUtf8(proof.proofValue).should.equal(
+              true,
+              'Expected proofValue value to be a valid UTF-8 encoded string.'
+            );
+          }
+        });
+        it('If options.type is not set to the string DataIntegrityProof or ' +
+          'options.cryptosuite is not set to the string ecdsa-jcs-2019, ' +
+          'an error MUST be raised and SHOULD convey an error type ' +
+          'of PROOF_TRANSFORMATION_ERROR.',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof.type,
+              'Expected a type identifier on the proof.');
+            should.exist(proof.cryptosuite,
+              'Expected a cryptosuite identifier on the proof.');
+            proof.type.should.equal('DataIntegrityProof',
+              'Expected DataIntegrityProof type.');
+            proof.cryptosuite.should.equal('ecdsa-jcs-2022',
+              'Expected ecdsa-jcs-2022 cryptosuite.');
+          }
+        });
+      });
+    }
+  });
+
+  describe('ecdsa-jcs-2019 - Algorithms - Proof Configuration', function() {
+    setupMatrix.call(this, issuerMatch);
+    let validCredential;
+    before(async function() {
+      validCredential = await createValidCredential();
+    });
+    for(const [columnId, {endpoints}] of issuerMatch) {
+      describe(columnId, function() {
+        const [issuer] = endpoints;
+        let issuedVc;
+        let proofs;
+        let ecdsa2022Proofs = [];
+        before(async function() {
+          issuedVc = await createInitialVc({issuer, vc: validCredential});
+          proofs = getProofs(issuedVc);
+          if(proofs?.length) {
+            ecdsa2022Proofs = proofs.filter(
+              proof => proof?.cryptosuite === cryptosuite);
+          }
+        });
+        beforeEach(setupRow);
+        const assertBefore = () => {
+          should.exist(issuedVc, 'Expected issuer to have issued a ' +
+                      'credential.');
+          should.exist(proofs, 'Expected credential to have a proof.');
+          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+                      'ecdsa-jcs-2019 cryptosuite.');
+        };
+        it('The proof options MUST contain a type identifier for the ' +
+          'cryptographic suite (type) and MUST contain a cryptosuite ' +
+          'identifier (cryptosuite).',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof.type,
+              'Expected a type identifier on the proof.');
+            should.exist(proof.cryptosuite,
+              'Expected a cryptosuite identifier on the proof.');
+          }
+        });
+        it('If proofConfig.type is not set to DataIntegrityProof ' +
+          'and/or proofConfig.cryptosuite is not set to ecdsa-jcs-2019, ' +
+          'an error MUST be raised and SHOULD convey an error type ' +
+          'of PROOF_GENERATION_ERROR.',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof.type,
+              'Expected a type identifier on the proof.');
+            should.exist(proof.cryptosuite,
+              'Expected a cryptosuite identifier on the proof.');
+            proof.type.should.equal('DataIntegrityProof',
+              'Expected DataIntegrityProof type.');
+            proof.cryptosuite.should.equal('ecdsa-jcs-2022',
+              'Expected ecdsa-jcs-2022 cryptosuite.');
+          }
+        });
+        it('If proofConfig.created is set and if the value is not a ' +
+          'valid [XMLSCHEMA11-2] datetime, an error MUST be raised and ' +
+          'SHOULD convey an error type of PROOF_GENERATION_ERROR.',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
+          for(const proof of ecdsa2022Proofs) {
+            if(proof?.created) {
+              isValidDatetime(proof.created).should.equal(
+                true,
+                'Expected created value to be a valid datetime string.'
+              );
+            }
+          }
+        });
+      });
+    }
+  });
+
+  describe('ecdsa-jcs-2019 - Algorithms - Transformation', function() {
+    setupMatrix.call(this, issuerMatch);
+    let validCredential;
+    before(async function() {
+      validCredential = await createValidCredential();
+    });
+    for(const [columnId, {endpoints}] of issuerMatch) {
+      describe(columnId, function() {
+        const [issuer] = endpoints;
+        let issuedVc;
+        let proofs;
+        let ecdsa2022Proofs = [];
+        before(async function() {
+          issuedVc = await createInitialVc({issuer, vc: validCredential});
+          proofs = getProofs(issuedVc);
+          if(proofs?.length) {
+            ecdsa2022Proofs = proofs.filter(
+              proof => proof?.cryptosuite === cryptosuite);
+          }
+        });
+        beforeEach(setupRow);
+        const assertBefore = () => {
+          should.exist(issuedVc, 'Expected issuer to have issued a ' +
+                      'credential.');
+          should.exist(proofs, 'Expected credential to have a proof.');
+          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+                      'ecdsa-jcs-2019 cryptosuite.');
+        };
+        it('The proof options MUST contain a type identifier for the ' +
+          'cryptographic suite (type) and MAY contain a cryptosuite ' +
+          'identifier (cryptosuite).',
+        async function() {
+          this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-serialization-ecdsa-jcs-2019';
+          assertBefore();
+          for(const proof of ecdsa2022Proofs) {
+            should.exist(proof.type,
+              'Expected a type identifier on the proof.');
+          }
+        });
+      });
+    }
+  });
+}

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -16,7 +16,7 @@ import chai from 'chai';
 import {endpoints} from 'vc-test-suite-implementations';
 
 export function ecdsaJcs2019Algorithms() {
-  const cryptosuite = 'ecdsa-jcs-2022';
+  const cryptosuite = 'ecdsa-jcs-2019';
   const {tags} = config.suites[
     cryptosuite
   ];

--- a/tests/suites/algorithms-jcs.js
+++ b/tests/suites/algorithms-jcs.js
@@ -38,12 +38,12 @@ export function ecdsaJcs2019Algorithms() {
         const [issuer] = endpoints;
         let issuedVc;
         let proofs;
-        let ecdsa2022Proofs = [];
+        let jcs2019Proofs = [];
         before(async function() {
           issuedVc = await createInitialVc({issuer, vc: validCredential});
           proofs = getProofs(issuedVc);
           if(proofs?.length) {
-            ecdsa2022Proofs = proofs.filter(
+            jcs2019Proofs = proofs.filter(
               proof => proof?.cryptosuite === cryptosuite);
           }
         });
@@ -52,7 +52,7 @@ export function ecdsaJcs2019Algorithms() {
           should.exist(issuedVc, 'Expected issuer to have issued a ' +
                       'credential.');
           should.exist(proofs, 'Expected credential to have a proof.');
-          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+          jcs2019Proofs.length.should.be.gte(1, 'Expected at least one ' +
                       'ecdsa-jcs-2019 cryptosuite.');
         };
         it('The transformation options MUST contain a type identifier ' +
@@ -61,7 +61,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof.type, 'Expected a type identifier on ' +
                               'the proof.');
             should.exist(proof.cryptosuite,
@@ -73,7 +73,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof?.proofValue,
               'Expected proofValue to exist.');
             isValidUtf8(proof.proofValue).should.equal(
@@ -89,7 +89,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#transformation-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof.type,
               'Expected a type identifier on the proof.');
             should.exist(proof.cryptosuite,
@@ -116,12 +116,12 @@ export function ecdsaJcs2019Algorithms() {
         const [issuer] = endpoints;
         let issuedVc;
         let proofs;
-        let ecdsa2022Proofs = [];
+        let jcs2019Proofs = [];
         before(async function() {
           issuedVc = await createInitialVc({issuer, vc: validCredential});
           proofs = getProofs(issuedVc);
           if(proofs?.length) {
-            ecdsa2022Proofs = proofs.filter(
+            jcs2019Proofs = proofs.filter(
               proof => proof?.cryptosuite === cryptosuite);
           }
         });
@@ -130,7 +130,7 @@ export function ecdsaJcs2019Algorithms() {
           should.exist(issuedVc, 'Expected issuer to have issued a ' +
                       'credential.');
           should.exist(proofs, 'Expected credential to have a proof.');
-          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+          jcs2019Proofs.length.should.be.gte(1, 'Expected at least one ' +
                       'ecdsa-jcs-2019 cryptosuite.');
         };
         it('The proof options MUST contain a type identifier for the ' +
@@ -139,7 +139,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof.type,
               'Expected a type identifier on the proof.');
             should.exist(proof.cryptosuite,
@@ -153,7 +153,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof.type,
               'Expected a type identifier on the proof.');
             should.exist(proof.cryptosuite,
@@ -169,7 +169,7 @@ export function ecdsaJcs2019Algorithms() {
           'SHOULD convey an error type of PROOF_GENERATION_ERROR.',
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-configuration-ecdsa-jcs-2019';
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             if(proof?.created) {
               isValidDatetime(proof.created).should.equal(
                 true,
@@ -194,12 +194,12 @@ export function ecdsaJcs2019Algorithms() {
         const [issuer] = endpoints;
         let issuedVc;
         let proofs;
-        let ecdsa2022Proofs = [];
+        let jcs2019Proofs = [];
         before(async function() {
           issuedVc = await createInitialVc({issuer, vc: validCredential});
           proofs = getProofs(issuedVc);
           if(proofs?.length) {
-            ecdsa2022Proofs = proofs.filter(
+            jcs2019Proofs = proofs.filter(
               proof => proof?.cryptosuite === cryptosuite);
           }
         });
@@ -208,7 +208,7 @@ export function ecdsaJcs2019Algorithms() {
           should.exist(issuedVc, 'Expected issuer to have issued a ' +
                       'credential.');
           should.exist(proofs, 'Expected credential to have a proof.');
-          ecdsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+          jcs2019Proofs.length.should.be.gte(1, 'Expected at least one ' +
                       'ecdsa-jcs-2019 cryptosuite.');
         };
         it('The proof options MUST contain a type identifier for the ' +
@@ -217,7 +217,7 @@ export function ecdsaJcs2019Algorithms() {
         async function() {
           this.test.link = 'https://www.w3.org/TR/vc-di-ecdsa/#proof-serialization-ecdsa-jcs-2019';
           assertBefore();
-          for(const proof of ecdsa2022Proofs) {
+          for(const proof of jcs2019Proofs) {
             should.exist(proof.type,
               'Expected a type identifier on the proof.');
           }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -211,14 +211,14 @@ async function _setup({
     await issueCloned(_generateNoTypeCryptosuite({
       signer,
       suiteName,
-      credential,
+      credential: _credential,
       mandatoryPointers,
       selectivePointers
     })));
   return credentials;
 }
 
-async function _generateNoTypeCryptosuite({
+function _generateNoTypeCryptosuite({
   signer,
   suiteName,
   credential,

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -95,7 +95,7 @@ export function ecdsaRdfc2019Algorithms({
   return describe(`${suiteName} - Algorithms - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...verifiers];
+    this.implemented = [];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     let credentials = new Map();
@@ -110,6 +110,7 @@ export function ecdsaRdfc2019Algorithms({
     });
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;
+      this.implemented.push(`${name}: ${keyType}`);
       describe(`${name}: ${keyType}`, function() {
         beforeEach(function() {
           this.currentTest.cell = {

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -47,6 +47,34 @@ export function ecdsaRdfc2019Algorithms({
           '(cryptosuite).', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
         });
+        it('Whenever this algorithm encodes strings, it MUST use UTF-8 ' +
+        'encoding. (proof.type)', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
+        });
+        it('If options.type is not set to the string DataIntegrityProof ' +
+        'and options.cryptosuite is not set to the string ecdsa-rdfc-2019, ' +
+        'an error MUST be raised ', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019:~:text=If%20options.type%20is%20not%20set%20to%20the%20string%20DataIntegrityProof%20and%20options.cryptosuite%20is%20not%20set%20to%20the%20string%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
+        });
+        it('The proof options MUST contain a type identifier for the ' +
+        'cryptographic suite (type) and MUST contain a cryptosuite ' +
+        'identifier (cryptosuite).', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
+        });
+        it('If proofConfig.type is not set to DataIntegrityProof and/or ' +
+        'proofConfig.cryptosuite is not set to ecdsa-rdfc-2019, an error ' +
+        'MUST be raised', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019:~:text=If%20proofConfig.type%20is%20not%20set%20to%20DataIntegrityProof%20and/or%20proofConfig.cryptosuite%20is%20not%20set%20to%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
+        });
+        it('If proofConfig.created is set and if the value is not a valid ' +
+        '[XMLSCHEMA11-2] datetime, an error MUST be raised', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
+        });
+        it('The proof options MUST contain a type identifier for the ' +
+        'cryptographic suite (type) and MAY contain a cryptosuite ' +
+        'identifier (cryptosuite).', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-serialization-ecdsa-rdfc-2019';
+        });
       });
     }
   });

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -8,6 +8,8 @@ import {
   issueCloned
 } from 'data-integrity-test-suite-assertion';
 import {createInitialVc, endpointCheck} from '../helpers.js';
+import {getMultiKey} from '../vc-generator/key-gen.js';
+import {getSuites} from './helpers.js';
 import {localVerifier} from '../vc-verifier/index.js';
 
 export function commonAlgorithms({
@@ -189,11 +191,36 @@ async function _setup({
   suiteName,
   keyType
 }) {
+  // stub suite canonize via Proxy cryptosuite.canonize and set safe to false
+  const credentials = new Map();
+  const keyPair = await getMultiKey({keyType});
+  const signer = keyPair.signer();
+  const _credential = structuredClone(credential);
+  _credential.issuer = keyPair.controller;
+  const {invalidCreated} = generators?.dates;
+  credentials.set('invalidCreated', await issueCloned(invalidCreated({
+    credential: structuredClone(_credential),
+    ...getSuites({
+      signer,
+      suiteName,
+      selectivePointers,
+      mandatoryPointers
+    })
+  })));
+  return credentials;
+}
+
+async function _generateNoTypeCryptosuite({
+  signer,
+  credential,
+  mandatoryPointers,
+  selectivePointers
+}) {
   const {
     invalidProofType,
     invalidCryptosuite
   } = generators?.mandatory;
-  const credentials = new Map();
-  const {invalidCreated} = generators?.dates;
+  const noType = invalidProofType({
 
+  });
 }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -213,7 +213,6 @@ async function _setup({
   suiteName,
   keyType
 }) {
-  // stub suite canonize via Proxy cryptosuite.canonize and set safe to false
   const credentials = new Map();
   const keyPair = await getMultiKey({keyType});
   const signer = keyPair.signer();
@@ -229,6 +228,7 @@ async function _setup({
       mandatoryPointers
     })
   })));
+  // stub suite canonize via Proxy cryptosuite.canonize and set safe to false
   credentials.set('noTypeOrCryptosuite',
     await issueCloned(_generateNoTypeCryptosuite({
       signer,
@@ -295,6 +295,38 @@ function unsafeProxy(suite) {
   });
 }
 
-function _commonSetup({}) {
+async function _commonSetup({
+  credential,
+  mandatoryPointers,
+  selectivePointers,
+  suiteName,
+  keyType
+}) {
+  const credentials = new Map();
+  const keyPair = await getMultiKey({keyType});
+  const signer = keyPair.signer();
+  const _credential = structuredClone(credential);
+  _credential.issuer = keyPair.controller;
+  const {suite, selectiveSuite} = getSuites({
+    signer,
+    suiteName,
+    selectivePointers,
+    mandatoryPointers
+  });
+  credentials.set('invalidHash', await issueCloned({
+    credential: _credential,
+    suite: invalidHashProxy({suite, suiteName}),
+    selectiveSuite: invalidHashProxy({suite: selectiveSuite, suiteName})
+  }));
+  return credentials;
+}
+
+function invalidHashProxy({
+  suiteName,
+  suite,
+}) {
+  if(typeof suite !== 'object') {
+    return suite;
+  }
 
 }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -248,6 +248,18 @@ function stubUnsafe(suite) {
   if(typeof suite !== 'object') {
     return suite;
   }
+  // if the suite has a cryptosuite object proxy it
+  if(suite._cryptosuite) {
+    suite._cryptosuite = new Proxy(suite._cryptosuite, {
+      get(target, prop) {
+        if(prop === 'canonize') {
+          return function(doc, options) {
+            return suite._cryptosuite.canonize(doc, {...options, safe: false});
+          };
+        }
+      }
+    });
+  }
   return new Proxy(suite, {
     get(target, prop) {
       if(prop === 'canonize') {

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -87,7 +87,7 @@ export function ecdsaRdfc2019Algorithms({
   verifiers,
   mandatoryPointers,
   selectivePointers,
-  keyType,
+  keyTypes,
   suiteName,
   vcVersion,
   setup = _setup
@@ -98,95 +98,106 @@ export function ecdsaRdfc2019Algorithms({
     this.implemented = [];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    let credentials = new Map();
+    const credentials = new Map(keyTypes.map(kt => [kt, null]));
     before(async function() {
-      credentials = await setup({
-        suiteName,
-        keyType,
-        credential,
-        mandatoryPointers,
-        selectivePointers
-      });
+      for(const keyType of keyTypes) {
+        credentials.set(keyType, await setup({
+          suiteName,
+          keyType,
+          credential,
+          mandatoryPointers,
+          selectivePointers
+        }));
+      }
     });
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;
-      this.implemented.push(`${name}: ${keyType}`);
-      describe(`${name}: ${keyType}`, function() {
-        beforeEach(function() {
-          this.currentTest.cell = {
-            rowId: this.currentTest.title,
-            columnId: this.currentTest.parent.title
-          };
-        });
-        it('The transformation options MUST contain a type identifier for ' +
-        'the cryptographic suite (type) and a cryptosuite identifier ' +
-          '(cryptosuite).', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('noTypeOrCryptosuite'),
-            reason: 'Should not verify VC w/ no type or cryptosuite identifier'
+      for(const keyType of keyTypes) {
+        this.implemented.push(`${name}: ${keyType}`);
+        describe(`${name}: ${keyType}`, function() {
+          beforeEach(function() {
+            this.currentTest.cell = {
+              rowId: this.currentTest.title,
+              columnId: this.currentTest.parent.title
+            };
+          });
+          it('The transformation options MUST contain a type identifier for ' +
+          'the cryptographic suite (type) and a cryptosuite identifier ' +
+            '(cryptosuite).', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('noTypeOrCryptosuite'),
+              reason: 'Should not verify VC w/ no type or cryptosuite ' +
+              'identifier'
+            });
+          });
+          it('Whenever this algorithm encodes strings, it MUST use UTF-8 ' +
+          'encoding. (proof.type)', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('notUTF8'),
+              reason: 'Should not verify VC w/ non UTF-8 encoding'
+            });
+          });
+          it('If options.type is not set to the string DataIntegrityProof ' +
+          'and options.cryptosuite is not set to the string ecdsa-rdfc-2019, ' +
+          'an error MUST be raised ', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019:~:text=If%20options.type%20is%20not%20set%20to%20the%20string%20DataIntegrityProof%20and%20options.cryptosuite%20is%20not%20set%20to%20the%20string%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('noTypeOrCryptosuite'),
+              reason: 'Should not verify VC w/ no type or cryptosuite ' +
+              'identifier'
+            });
+          });
+          it('The proof options MUST contain a type identifier for the ' +
+          'cryptographic suite (type) and MUST contain a cryptosuite ' +
+          'identifier (cryptosuite).', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('noTypeOrCryptosuite'),
+              reason: 'Should not verify VC w/ no type or cryptosuite ' +
+              'identifier'
+            });
+          });
+          it('If proofConfig.type is not set to DataIntegrityProof and/or ' +
+          'proofConfig.cryptosuite is not set to ecdsa-rdfc-2019, an error ' +
+          'MUST be raised', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019:~:text=If%20proofConfig.type%20is%20not%20set%20to%20DataIntegrityProof%20and/or%20proofConfig.cryptosuite%20is%20not%20set%20to%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('noTypeOrCryptosuite'),
+              reason: 'Should not verify VC w/ no type or cryptosuite ' +
+              'identifier'
+            });
+          });
+          it('If proofConfig.created is set and if the value is not a valid ' +
+          '[XMLSCHEMA11-2] datetime, an error MUST be raised',
+          async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('invalidCreated'),
+              reason: 'Should not verify VC w/ invalid "proof.created"'
+            });
+          });
+          it('The proof options MUST contain a type identifier for the ' +
+          'cryptographic suite (type) and MAY contain a cryptosuite ' +
+          'identifier (cryptosuite).', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-serialization-ecdsa-rdfc-2019';
+            await assertions.verificationFail({
+              verifier,
+              credentials: credentials.get('noTypeOrCryptosuite'),
+              reason: 'Should not verify VC w/ no type or cryptosuite ' +
+              'identifier'
+            });
           });
         });
-        it('Whenever this algorithm encodes strings, it MUST use UTF-8 ' +
-        'encoding. (proof.type)', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('notUTF8'),
-            reason: 'Should not verify VC w/ non UTF-8 encoding'
-          });
-        });
-        it('If options.type is not set to the string DataIntegrityProof ' +
-        'and options.cryptosuite is not set to the string ecdsa-rdfc-2019, ' +
-        'an error MUST be raised ', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019:~:text=If%20options.type%20is%20not%20set%20to%20the%20string%20DataIntegrityProof%20and%20options.cryptosuite%20is%20not%20set%20to%20the%20string%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('noTypeOrCryptosuite'),
-            reason: 'Should not verify VC w/ no type or cryptosuite identifier'
-          });
-        });
-        it('The proof options MUST contain a type identifier for the ' +
-        'cryptographic suite (type) and MUST contain a cryptosuite ' +
-        'identifier (cryptosuite).', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('noTypeOrCryptosuite'),
-            reason: 'Should not verify VC w/ no type or cryptosuite identifier'
-          });
-        });
-        it('If proofConfig.type is not set to DataIntegrityProof and/or ' +
-        'proofConfig.cryptosuite is not set to ecdsa-rdfc-2019, an error ' +
-        'MUST be raised', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019:~:text=If%20proofConfig.type%20is%20not%20set%20to%20DataIntegrityProof%20and/or%20proofConfig.cryptosuite%20is%20not%20set%20to%20ecdsa%2Drdfc%2D2019%2C%20an%20error%20MUST%20be%20raised';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('noTypeOrCryptosuite'),
-            reason: 'Should not verify VC w/ no type or cryptosuite identifier'
-          });
-        });
-        it('If proofConfig.created is set and if the value is not a valid ' +
-        '[XMLSCHEMA11-2] datetime, an error MUST be raised', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-configuration-ecdsa-rdfc-2019';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('invalidCreated'),
-            reason: 'Should not verify VC w/ invalid "proof.created"'
-          });
-        });
-        it('The proof options MUST contain a type identifier for the ' +
-        'cryptographic suite (type) and MAY contain a cryptosuite ' +
-        'identifier (cryptosuite).', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#proof-serialization-ecdsa-rdfc-2019';
-          await assertions.verificationFail({
-            verifier,
-            credentials: credentials.get('noTypeOrCryptosuite'),
-            reason: 'Should not verify VC w/ no type or cryptosuite identifier'
-          });
-        });
-      });
+
+      }
     }
   });
 }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export function algorithmSuite({
+  suiteName
+}) {
+  it('When generating ECDSA signatures, the signature value MUST be ' +
+    'expressed according to section 7 of [RFC4754] (sometimes referred to ' +
+    'as the IEEE P1363 format) and encoded according to the specific ' +
+    'cryptosuite proof generation algorithm.', async function() {
+    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=When%20generating%20ECDSA%20signatures%2C%20the%20signature%20value%20MUST%20be%20expressed%20according%20to%20section%207%20of%20%5BRFC4754%5D%20(sometimes%20referred%20to%20as%20the%20IEEE%20P1363%20format)%20and%20encoded%20according%20to%20the%20specific%20cryptosuite%20proof%20generation%20algorithm';
+  });
+  it('For P-256 keys, the default hashing function, SHA-2 with 256 bits of ' +
+    'output, MUST be used.', async function() {
+    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D256%20keys%2C%20the%20default%20hashing%20function%2C%20SHA%2D2%20with%20256%20bits%20of%20output%2C%20MUST%20be%20used.';
+  });
+  it('For P-384 keys, SHA-2 with 384-bits of output MUST be used, specified ' +
+    'via the RDFC-1.0 implementation-specific parameter.', async function() {
+    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D384%20keys%2C%20SHA%2D2%20with%20384%2Dbits%20of%20output%20MUST%20be%20used%2C%20specified%20via%20the%20RDFC%2D1.0%20implementation%2Dspecific%20parameter.';
+  });
+}
+
+export function ecdsaRdfc2019Algorithms({
+  suiteName,
+  vcVersion
+}) {
+  return describe(`${suiteName} - Algorithms - VC ${vcVersion}`, function() {
+    it('The transformation options MUST contain a type identifier for the ' +
+      'cryptographic suite (type) and a cryptosuite identifier (cryptosuite).',
+    async function() {
+      this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
+    });
+  });
+}

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -23,6 +23,11 @@ export function commonAlgorithms({
 }) {
   const title = `${suiteName} - Algorithms Common - VC ${vcVersion}`;
   return describe(title, function() {
+    this.matrix = true;
+    this.report = true;
+    this.implemented = [];
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Implementation';
     const credentials = new Map(keyTypes.map(keyType => [keyType, null]));
     before(async function() {
       for(const keyType of keyTypes) {
@@ -39,6 +44,7 @@ export function commonAlgorithms({
     });
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;
+      this.implemented.push(`${name}`);
       describe(`${name}`, function() {
         beforeEach(function() {
           this.currentTest.cell = {
@@ -345,6 +351,7 @@ function invalidHashProxy({
             cryptosuite, document, proof,
             documentLoader, dataIntegrityProof
           } = {}) {
+            // this switch the hash to the wrong hash for that keyType
             const algorithm = (keyType === 'P-256') ? 'sha384' : 'sha256';
             const c14nOptions = {
               documentLoader,

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -8,25 +8,60 @@ import {expect} from 'chai';
 export function algorithmSuite({
   suiteName
 }) {
-  it('When generating ECDSA signatures, the signature value MUST be ' +
-    'expressed according to section 7 of [RFC4754] (sometimes referred to ' +
-    'as the IEEE P1363 format) and encoded according to the specific ' +
-    'cryptosuite proof generation algorithm.', async function() {
-    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=When%20generating%20ECDSA%20signatures%2C%20the%20signature%20value%20MUST%20be%20expressed%20according%20to%20section%207%20of%20%5BRFC4754%5D%20(sometimes%20referred%20to%20as%20the%20IEEE%20P1363%20format)%20and%20encoded%20according%20to%20the%20specific%20cryptosuite%20proof%20generation%20algorithm';
-  });
-  it('For P-256 keys, the default hashing function, SHA-2 with 256 bits of ' +
-    'output, MUST be used.', async function() {
-    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D256%20keys%2C%20the%20default%20hashing%20function%2C%20SHA%2D2%20with%20256%20bits%20of%20output%2C%20MUST%20be%20used.';
-  });
-  it('For P-384 keys, SHA-2 with 384-bits of output MUST be used, specified ' +
-    'via the RDFC-1.0 implementation-specific parameter.', async function() {
-    this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D384%20keys%2C%20SHA%2D2%20with%20384%2Dbits%20of%20output%20MUST%20be%20used%2C%20specified%20via%20the%20RDFC%2D1.0%20implementation%2Dspecific%20parameter.';
-  });
+}
+
+export function commonAlgorithms({
+  credential,
+  issuers,
+  mandatoryPointers,
+  keyType,
+  suiteName,
+  vcVersion
+}) {
+  for(const [name, {endpoints}] of issuers) {
+    const [issuer] = endpoints;
+    // does the endpoint support this test?
+    if(!endpointCheck({endpoint: issuer, keyType, vcVersion})) {
+      continue;
+    }
+    describe(`${name}: ${keyType}`, function() {
+      let securedCredential = null;
+      let proofs = [];
+      before(async function() {
+        securedCredential = await createInitialVc({
+          issuer,
+          vcVersion,
+          vc: credential,
+          mandatoryPointers
+        });
+        if(securedCredential) {
+          proofs = Array.isArray(securedCredential.proof) ?
+            securedCredential?.proof : [securedCredential?.proof];
+          // only test proofs that match the relevant cryptosuite
+          proofs = proofs.filter(p => p?.cryptosuite === suiteName);
+        }
+      });
+      it('When generating ECDSA signatures, the signature value MUST be ' +
+        'expressed according to section 7 of [RFC4754] (sometimes referred to ' +
+        'as the IEEE P1363 format) and encoded according to the specific ' +
+        'cryptosuite proof generation algorithm.', async function() {
+        this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=When%20generating%20ECDSA%20signatures%2C%20the%20signature%20value%20MUST%20be%20expressed%20according%20to%20section%207%20of%20%5BRFC4754%5D%20(sometimes%20referred%20to%20as%20the%20IEEE%20P1363%20format)%20and%20encoded%20according%20to%20the%20specific%20cryptosuite%20proof%20generation%20algorithm';
+      });
+      it('For P-256 keys, the default hashing function, SHA-2 with 256 bits of ' +
+        'output, MUST be used.', async function() {
+        this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D256%20keys%2C%20the%20default%20hashing%20function%2C%20SHA%2D2%20with%20256%20bits%20of%20output%2C%20MUST%20be%20used.';
+      });
+      it('For P-384 keys, SHA-2 with 384-bits of output MUST be used, specified ' +
+        'via the RDFC-1.0 implementation-specific parameter.', async function() {
+        this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D384%20keys%2C%20SHA%2D2%20with%20384%2Dbits%20of%20output%20MUST%20be%20used%2C%20specified%20via%20the%20RDFC%2D1.0%20implementation%2Dspecific%20parameter.';
+      });
+    });
+  }
 }
 
 export function ecdsaRdfc2019Algorithms({
   credential,
-  endpoints,
+  verifiers,
   mandatoryPointers,
   keyType,
   suiteName,
@@ -35,13 +70,13 @@ export function ecdsaRdfc2019Algorithms({
   return describe(`${suiteName} - Algorithms - VC ${vcVersion}`, function() {
     this.matrix = true;
     this.report = true;
-    this.implemented = [...endpoints];
+    this.implemented = [...verifiers];
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
-    for(const [name, {endpoints: issuers}] of endpoints) {
-      const [issuer] = issuers;
+    for(const [name, {endpoints}] of verifiers) {
+      const [verifier] = endpoints;
       // does the endpoint support this test?
-      if(!endpointCheck({endpoint: issuer, keyType, vcVersion})) {
+      if(!endpointCheck({endpoint: verifier, keyType, vcVersion})) {
         continue;
       }
       describe(`${name}: ${keyType}`, function() {
@@ -75,14 +110,6 @@ export function ecdsaRdfc2019Algorithms({
         it('Whenever this algorithm encodes strings, it MUST use UTF-8 ' +
         'encoding. (proof.type)', async function() {
           this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
-          for(const proof of proofs) {
-            expect(proof?.type).to.exist;
-            expect(proof.type).to.be.a('string');
-            expect(
-              proof.type.isWellFormed(),
-              'Expected string to be a well formed UTF string'
-            ).to.be.true;
-          }
         });
         it('If options.type is not set to the string DataIntegrityProof ' +
         'and options.cryptosuite is not set to the string ecdsa-rdfc-2019, ' +

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -58,25 +58,29 @@ export function commonAlgorithms({
             });
           }
         });
-        it('For P-256 keys, the default hashing function, SHA-2 with 256 bits' +
-          'of output, MUST be used.', async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D256%20keys%2C%20the%20default%20hashing%20function%2C%20SHA%2D2%20with%20256%20bits%20of%20output%2C%20MUST%20be%20used.';
-          await assertions.verificationSuccess({
-            credential: credentials.get('P-256').get('invalidHash'),
-            verifier,
-            reason: `Should not verify VC with invalid hash.`
+        if(keyTypes.includes('P-256')) {
+          it('For P-256 keys, the default hashing function, SHA-2 with 256 ' +
+            'bits of output, MUST be used.', async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D256%20keys%2C%20the%20default%20hashing%20function%2C%20SHA%2D2%20with%20256%20bits%20of%20output%2C%20MUST%20be%20used.';
+            await assertions.verificationSuccess({
+              credential: credentials.get('P-256').get('invalidHash'),
+              verifier,
+              reason: `Should not verify VC with invalid hash.`
+            });
           });
-        });
-        it('For P-384 keys, SHA-2 with 384-bits of output MUST be used, ' +
-          'specified via the RDFC-1.0 implementation-specific parameter.',
-        async function() {
-          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D384%20keys%2C%20SHA%2D2%20with%20384%2Dbits%20of%20output%20MUST%20be%20used%2C%20specified%20via%20the%20RDFC%2D1.0%20implementation%2Dspecific%20parameter.';
-          await assertions.verificationFail({
-            credential: credentials.get('P-384').get('invalidHash'),
-            verifier,
-            reason: `Should not verify VC with invalid hash.`
+        }
+        if(keyTypes.includes('P-384')) {
+          it('For P-384 keys, SHA-2 with 384-bits of output MUST be used, ' +
+            'specified via the RDFC-1.0 implementation-specific parameter.',
+          async function() {
+            this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#algorithms:~:text=For%20P%2D384%20keys%2C%20SHA%2D2%20with%20384%2Dbits%20of%20output%20MUST%20be%20used%2C%20specified%20via%20the%20RDFC%2D1.0%20implementation%2Dspecific%20parameter.';
+            await assertions.verificationFail({
+              credential: credentials.get('P-384').get('invalidHash'),
+              verifier,
+              reason: `Should not verify VC with invalid hash.`
+            });
           });
-        });
+        }
       });
     }
   });

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -38,6 +38,12 @@ export function commonAlgorithms({
           mandatoryPointers
         });
       });
+      beforeEach(function() {
+        this.currentTest.cell = {
+          rowId: this.currentTest.title,
+          columnId: this.currentTest.parent.title
+        };
+      });
       it('When generating ECDSA signatures, the signature value MUST be ' +
         'expressed according to section 7 of [RFC4754] (sometimes referred ' +
         'to as the IEEE P1363 format) and encoded according to the specific ' +
@@ -254,7 +260,7 @@ function unsafeProxy(suite) {
       get(target, prop) {
         if(prop === 'canonize') {
           return function(doc, options) {
-            return suite._cryptosuite.canonize(doc, {...options, safe: false});
+            return target.canonize(doc, {...options, safe: false});
           };
         }
         return Reflect.get(...arguments);
@@ -265,7 +271,7 @@ function unsafeProxy(suite) {
     get(target, prop) {
       if(prop === 'canonize') {
         return function(doc, options) {
-          return suite.canonize(doc, {...options, safe: false});
+          return target.canonize(doc, {...options, safe: false});
         };
       }
       return Reflect.get(...arguments);

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -237,14 +237,14 @@ function _generateNoTypeCryptosuite({
   } = generators?.mandatory;
   const noType = invalidProofType({
     credential: structuredClone(credential),
-    suite: stubUnsafe(suite),
-    selectiveSuite: stubUnsafe(selectiveSuite),
+    suite: unsafeProxy(suite),
+    selectiveSuite: unsafeProxy(selectiveSuite),
     proofType: ''
   });
   return invalidCryptosuite({...noType, cryptosuiteName: ''});
 }
 
-function stubUnsafe(suite) {
+function unsafeProxy(suite) {
   if(typeof suite !== 'object') {
     return suite;
   }
@@ -257,6 +257,7 @@ function stubUnsafe(suite) {
             return suite._cryptosuite.canonize(doc, {...options, safe: false});
           };
         }
+        return Reflect.get(...arguments);
       }
     });
   }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -23,14 +23,31 @@ export function algorithmSuite({
 }
 
 export function ecdsaRdfc2019Algorithms({
+  endpoints,
   suiteName,
+  keyType,
   vcVersion
 }) {
   return describe(`${suiteName} - Algorithms - VC ${vcVersion}`, function() {
-    it('The transformation options MUST contain a type identifier for the ' +
-      'cryptographic suite (type) and a cryptosuite identifier (cryptosuite).',
-    async function() {
-      this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
-    });
+    this.matrix = true;
+    this.report = true;
+    this.implemented = [...endpoints];
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Implementation';
+    for(const [name, {endpoints: issuers}] of endpoints) {
+      describe(`${name}: ${keyType}`, function() {
+        beforeEach(function() {
+          this.currentTest.cell = {
+            rowId: this.currentTest.title,
+            columnId: this.currentTest.parent.title
+          };
+        });
+        it('The transformation options MUST contain a type identifier for ' +
+        'the cryptographic suite (type) and a cryptosuite identifier ' +
+          '(cryptosuite).', async function() {
+          this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#transformation-ecdsa-rdfc-2019';
+        });
+      });
+    }
   });
 }

--- a/tests/suites/algorithms.js
+++ b/tests/suites/algorithms.js
@@ -8,7 +8,6 @@ import {
   issueCloned
 } from 'data-integrity-test-suite-assertion';
 import {createInitialVc, endpointCheck} from '../helpers.js';
-import {expect} from 'chai';
 import {localVerifier} from '../vc-verifier/index.js';
 
 export function commonAlgorithms({
@@ -83,7 +82,7 @@ export function ecdsaRdfc2019Algorithms({
   keyType,
   suiteName,
   vcVersion,
-  suite = _suite
+  setup = _setup
 }) {
   return describe(`${suiteName} - Algorithms - VC ${vcVersion}`, function() {
     this.matrix = true;
@@ -183,8 +182,18 @@ export function ecdsaRdfc2019Algorithms({
   });
 }
 
-async function _suite({
-
+async function _setup({
+  credential,
+  mandatoryPointers,
+  selectivePointers,
+  suiteName,
+  keyType
 }) {
+  const {
+    invalidProofType,
+    invalidCryptosuite
+  } = generators?.mandatory;
+  const credentials = new Map();
+  const {invalidCreated} = generators?.dates;
 
 }

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -41,7 +41,7 @@ export function conformanceSuite({
     for(const [name, {endpoints}] of verifiers) {
       const [verifier] = endpoints;
       for(const keyType of keyTypes) {
-      // add implementer name and keyType to test report
+        // add implementer name and keyType to test report
         this.implemented.push(`${name}: ${keyType}`);
         describe(`${name}: ${keyType}`, function() {
           beforeEach(function() {

--- a/tests/suites/conformance.js
+++ b/tests/suites/conformance.js
@@ -7,9 +7,8 @@ import {
   generators,
   issueCloned
 } from 'data-integrity-test-suite-assertion';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {getMultiKey} from '../vc-generator/key-gen.js';
-import {getSuite} from '../vc-generator/cryptosuites.js';
+import {getSuites} from './helpers.js';
 
 export function conformanceSuite({
   verifiers,
@@ -101,7 +100,7 @@ async function _setup({
   // invalid cryptosuite name invalidCryptosuite
   credentials.set('invalid cryptosuite', await issueCloned(invalidCryptosuite({
     credential: structuredClone(_credential),
-    ..._getSuites({
+    ...getSuites({
       signer,
       suiteName,
       selectivePointers,
@@ -110,7 +109,7 @@ async function _setup({
   })));
   credentials.set('invalid VerificationMethod', await issueCloned(invalidVm({
     credential: structuredClone(_credential),
-    ..._getSuites({
+    ...getSuites({
       signer,
       suiteName,
       selectivePointers,
@@ -119,7 +118,7 @@ async function _setup({
   })));
   credentials.set('invalid Proof Type', await issueCloned(invalidProofType({
     credential: structuredClone(_credential),
-    ..._getSuites({
+    ...getSuites({
       signer,
       suiteName,
       selectivePointers,
@@ -127,31 +126,4 @@ async function _setup({
     })
   })));
   return credentials;
-}
-
-function _getSuites({
-  signer,
-  suiteName,
-  mandatoryPointers,
-  selectivePointers
-}) {
-  const suites = {
-    suite: new DataIntegrityProof({
-      signer,
-      cryptosuite: getSuite({
-        suite: suiteName,
-        mandatoryPointers
-      })
-    })
-  };
-  if(selectivePointers) {
-    suites.selectiveSuite = new DataIntegrityProof({
-      signer,
-      cryptosuite: getSuite({
-        suite: suiteName,
-        selectivePointers
-      })
-    });
-  }
-  return suites;
 }

--- a/tests/suites/helpers.js
+++ b/tests/suites/helpers.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright 2024 Digital Bazaar, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {getSuite} from '../vc-generator/cryptosuites.js';
+
+// FIXME:an existing function in data integrity test suite assertion
+// does something similar to this function, but is not currently exported
+export function getSuites({
+  signer,
+  suiteName,
+  mandatoryPointers,
+  selectivePointers
+}) {
+  const suites = {
+    suite: new DataIntegrityProof({
+      signer,
+      cryptosuite: getSuite({
+        suite: suiteName,
+        mandatoryPointers
+      })
+    })
+  };
+  if(selectivePointers) {
+    suites.selectiveSuite = new DataIntegrityProof({
+      signer,
+      cryptosuite: getSuite({
+        suite: suiteName,
+        selectivePointers
+      })
+    });
+  }
+  return suites;
+}


### PR DESCRIPTION
Algorithms is the largest section in the ecdsa spec.
This PR collects each individual algorithm suite for each cryptosuite after review
Add Tests for

- [x] ecdsa-rdfc-2019 (@aljones15 )
- [x] ecdsa-jcs-2019 (@PatStLouis 
- [ ] ecdsa-sd-2023 (@aljones15)


This PR is intended to be the major stop for all of the Algorithm related PRs and tests. It should be merged into `add-conformance-suite` or `main` on approval.