### PR TITLE
Add 3 ecdsa-sd-2023 proof value tests (D -> C)

### DIFF
--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -13,6 +13,7 @@ import {klona} from 'klona';
 import varint from 'varint';
 
 const should = chai.should();
+const {expect} = chai;
 
 // RegExp with bs58 characters in it
 const bs58 =
@@ -181,4 +182,37 @@ export function itRejectsInvalidCryptosuite(expectedValidSuites, {
     credential.proof.cryptosuite = 'invalid-cryptosuite';
     await verificationFail({credential, verifier: endpoint});
   });
+}
+
+export async function shouldBeBaseProofValue({proof, name}) {
+  expect(
+    proof,
+    `Expected VC from issuer ${name} to have an ' +
+    '"ecdsa-sd-2023" proof`).to.exist;
+  expect(
+    proof.proofValue,
+    `Expected VC from issuer ${name} to have a ' +
+    '"proof.proofValue"`
+  ).to.exist;
+  expect(
+    proof.proofValue,
+    `Expected VC "proof.proofValue" from issuer ${name} to be ` +
+    'a string.'
+  ).to.be.a.string;
+  //Ensure the proofValue string starts with u, indicating that it
+  //is a multibase-base64url-no-pad-encoded value, throwing an
+  //error if it does not.
+  expect(
+    proof.proofValue.startsWith('u'),
+    `Expected "proof.proofValue" to start with u received ` +
+    `${proof.proofValue[0]}`).to.be.true;
+  // now test the encoding which is bs64 url no pad for this suite
+  expect(
+    shouldBeBs64UrlNoPad(proof.proofValue),
+    'Expected "proof.proofValue" to be bs64 url no pad encoded.'
+  ).to.be.true;
+  await shouldHaveHeaderBytes(
+    proof.proofValue,
+    new Uint8Array([0xd9, 0x5d, 0x00])
+  );
 }

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -30,18 +30,18 @@ export const proofBytes = {
   'P-384': 96
 };
 
-export const shouldHaveByteLength = async (
+export const shouldHaveByteLength = (
   multibaseString,
   expectedByteLength
 ) => {
-  const bytes = await getBs58Bytes(multibaseString);
+  const bytes = getBs58Bytes(multibaseString);
   bytes.length.should.eql(
     expectedByteLength,
     `Expected byteLength of ${expectedByteLength} received ${bytes.length}.`);
 };
 
-export const shouldHaveHeaderBytes = async (multibaseString, headerBytes) => {
-  const bytes = await getBs64UrlBytes(multibaseString);
+export const shouldHaveHeaderBytes = (multibaseString, headerBytes) => {
+  const bytes = getBs64UrlBytes(multibaseString);
   const actualHeaderBytes = Array.from(bytes.slice(0, headerBytes.length));
   actualHeaderBytes.should.eql(
     Array.from(headerBytes),
@@ -54,7 +54,7 @@ export const shouldBeMulticodecEncoded = async s => {
   if(s.startsWith(multibaseMultikeyHeaderP256)) {
     // example of a P-256 publicKeyMultibase -
     // zDnaepHgv4AU1btQ8dp6EYbvgJ6M1ovzKnSpXJUPU2hshXLvp
-    const bytes = await getBs58Bytes(s);
+    const bytes = getBs58Bytes(s);
     bytes.length.should.equal(35);
     // bytes example => Uint8Array(35) [
     //   128,  36,   3,  98, 121, 153, 205, 199,
@@ -72,7 +72,7 @@ export const shouldBeMulticodecEncoded = async s => {
   }
 
   if(s.startsWith(multibaseMultikeyHeaderP384)) {
-    const bytes = await getBs58Bytes(s);
+    const bytes = getBs58Bytes(s);
     bytes.length.should.equal(51);
     // get the two-byte prefix
     const prefix = Array.from(bytes.slice(0, 2));
@@ -211,7 +211,7 @@ export async function shouldBeBaseProofValue({proof, name}) {
     shouldBeBs64UrlNoPad(proof.proofValue),
     'Expected "proof.proofValue" to be bs64 url no pad encoded.'
   ).to.be.true;
-  await shouldHaveHeaderBytes(
+  shouldHaveHeaderBytes(
     proof.proofValue,
     new Uint8Array([0xd9, 0x5d, 0x00])
   );

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -16,6 +16,7 @@ export const require = createRequire(import.meta.url);
 // and gets the bytes
 export const getBs58Bytes = s => bs58.decode(s.slice(1));
 export const getBs64UrlBytes = s => bs64.decode(s.slice(1));
+export const encodeBs64Url = bytes => bs64.encode(bytes);
 
 // Javascript's default ISO timestamp contains milliseconds.
 // This lops off the MS part of the UTC RFC3339 TimeStamp and replaces

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -14,8 +14,8 @@ export const require = createRequire(import.meta.url);
 
 // takes a multibase string starting with z lops the z off
 // and gets the bytes
-export const getBs58Bytes = async s => bs58.decode(s.slice(1));
-export const getBs64UrlBytes = async s => bs64.decode(s.slice(1));
+export const getBs58Bytes = s => bs58.decode(s.slice(1));
+export const getBs64UrlBytes = s => bs64.decode(s.slice(1));
 
 // Javascript's default ISO timestamp contains milliseconds.
 // This lops off the MS part of the UTC RFC3339 TimeStamp and replaces

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -166,7 +166,8 @@ export function sd2023Algorithms({
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=If%20the%20decodedProofValue%20does%20not%20start%20with%20the%20ECDSA%2DSD%20disclosure%20proof%20header%20bytes%200xd9%2C%200x5d%2C%20and%200x01%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.';
             await assertions.verificationFail({
               verifier,
-              credential: fixtures.get('invalidDisclosureProofHeader'),
+              credential: fixtures.get(keyType).get(
+                'invalidDisclosureProofHeader'),
               reason: 'Should not verify VC with invalid disclosure proof ' +
               'header'
             });

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -8,6 +8,7 @@ import {
   issueCloned
 } from 'data-integrity-test-suite-assertion';
 import {
+  shouldBeBaseProofValue,
   shouldBeBs64UrlNoPad,
   shouldHaveHeaderBytes,
 } from '../assertions.js';
@@ -93,38 +94,8 @@ export function sd2023Algorithms({
           'specific cryptosuite proof generation algorithm.', async function() {
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#base-proof-serialization-ecdsa-sd-2023:~:text=When%20generating%20ECDSA%20signatures%2C%20the%20signature%20value%20MUST%20be%20expressed%20according%20to%20section%207';
             assertIssuer();
-            const _proof = proofs.find(p =>
-              p?.cryptosuite === 'ecdsa-sd-2023');
-            expect(
-              _proof,
-              `Expected VC from issuer ${name} to have an ' +
-              '"ecdsa-sd-2023" proof`).to.exist;
-            expect(
-              _proof.proofValue,
-              `Expected VC from issuer ${name} to have a ' +
-              '"proof.proofValue"`
-            ).to.exist;
-            expect(
-              _proof.proofValue,
-              `Expected VC "proof.proofValue" from issuer ${name} to be ` +
-              'a string.'
-            ).to.be.a.string;
-            //Ensure the proofValue string starts with u, indicating that it
-            //is a multibase-base64url-no-pad-encoded value, throwing an
-            //error if it does not.
-            expect(
-              _proof.proofValue.startsWith('u'),
-              `Expected "proof.proofValue" to start with u received ` +
-              `${_proof.proofValue[0]}`).to.be.true;
-            // now test the encoding which is bs64 url no pad for this suite
-            expect(
-              shouldBeBs64UrlNoPad(_proof.proofValue),
-              'Expected "proof.proofValue" to be bs64 url no pad encoded.'
-            ).to.be.true;
-            await shouldHaveHeaderBytes(
-              _proof.proofValue,
-              new Uint8Array([0xd9, 0x5d, 0x00])
-            );
+            const proof = proofs.find(p => p?.cryptosuite === 'ecdsa-sd-2023');
+            await shouldBeBaseProofValue({proof, name});
           });
           it('If source has an id that is not a blank node identifier, set ' +
           'selection.id to its value. Note: All non-blank node identifiers ' +
@@ -184,9 +155,9 @@ export function sd2023Algorithms({
           'raised and SHOULD convey an error type of PROOF_VERIFICATION_ERROR.',
           async function() {
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=If%20the%20decodedProofValue%20does%20not%20start%20with%20the%20ECDSA%2DSD%20base%20proof%20header%20bytes%200xd9%2C%200x5d%2C%20and%200x00%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.';
-            this.test.cell.skipMessage = 'Not Implemented';
-            this.skip();
             assertIssuer();
+            const proof = proofs.find(p => p?.cryptosuite === 'ecdsa-sd-2023');
+            await shouldBeBaseProofValue({proof, name});
           });
           it('If the decodedProofValue does not start with the ECDSA-SD ' +
           'disclosure proof header bytes 0xd9, 0x5d, and 0x01, an error ' +

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -173,15 +173,11 @@ export function sd2023Algorithms({
           'MUST be raised and SHOULD convey an error type of ' +
           'PROOF_VERIFICATION_ERROR.', async function() {
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=produced%20as%20output.-,If%20the%20proofValue%20string%20does%20not%20start%20with%20u%2C%20indicating%20that%20it%20is%20a%20multibase%2Dbase64url%2Dno%2Dpad%2Dencoded%20value%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.,-Initialize%20decodedProofValue%20to';
-            this.test.cell.skipMessage = 'Not Implemented';
-            this.skip();
-            /*
             await assertions.verificationFail({
               verifier,
-              credential: fixtures.get('invalidProofValuePrefix'),
+              credential: fixtures.get(keyType).get('invalidProofValuePrefix'),
               reason: 'Should not verify VC with invalid proofValue prefix'
             });
-            */
           });
           it('If the decodedProofValue does not start with the ECDSA-SD ' +
           'base proof header bytes 0xd9, 0x5d, and 0x00, an error MUST be ' +
@@ -190,13 +186,7 @@ export function sd2023Algorithms({
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=If%20the%20decodedProofValue%20does%20not%20start%20with%20the%20ECDSA%2DSD%20base%20proof%20header%20bytes%200xd9%2C%200x5d%2C%20and%200x00%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.';
             this.test.cell.skipMessage = 'Not Implemented';
             this.skip();
-            /*
-            await assertions.verificationFail({
-              verifier,
-              credential: fixtures.get('invalidBaseProofHeader'),
-              reason: 'Should not verify VC with invalid base proof header'
-            });
-            */
+            assertIssuer();
           });
           it('If the decodedProofValue does not start with the ECDSA-SD ' +
           'disclosure proof header bytes 0xd9, 0x5d, and 0x01, an error ' +
@@ -367,5 +357,18 @@ async function _setup({
     suite: cborTagSuites.suite,
     selectiveSuite: invalidCborTagProxy(cborTagSuites.selectiveSuite)
   }));
+  const securedCredential = await issueCloned({
+    credential: _credential,
+    ...getSuites({
+      signer,
+      suiteName,
+      selectivePointers,
+      mandatoryPointers
+    })
+  });
+  const nonbase64ProofValue = structuredClone(securedCredential);
+  nonbase64ProofValue.proof.proofValue =
+    nonbase64ProofValue.proof.proofValue.substring(1);
+  credentials.set('invalidProofValuePrefix', nonbase64ProofValue);
   return credentials;
 }

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -8,6 +8,7 @@ import {
   issueCloned
 } from 'data-integrity-test-suite-assertion';
 import {createInitialVc, getBs64UrlBytes} from '../helpers.js';
+import {expect} from 'chai';
 import {getMultiKey} from '../vc-generator/key-gen.js';
 import {getSuites} from './helpers.js';
 import {invalidCborTagProxy} from './proxies.js';

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -7,16 +7,11 @@ import {
   generators,
   issueCloned
 } from 'data-integrity-test-suite-assertion';
-import {
-  shouldBeBaseProofValue,
-  shouldBeBs64UrlNoPad,
-  shouldHaveHeaderBytes,
-} from '../assertions.js';
-import {createInitialVc} from '../helpers.js';
-import {expect} from 'chai';
+import {createInitialVc, getBs64UrlBytes} from '../helpers.js';
 import {getMultiKey} from '../vc-generator/key-gen.js';
 import {getSuites} from './helpers.js';
 import {invalidCborTagProxy} from './proxies.js';
+import {shouldBeBaseProofValue} from '../assertions.js';
 
 export function sd2023Algorithms({
   credential,
@@ -164,16 +159,12 @@ export function sd2023Algorithms({
           'MUST be raised and SHOULD convey an error type of ' +
           'PROOF_VERIFICATION_ERROR.', async function() {
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=If%20the%20decodedProofValue%20does%20not%20start%20with%20the%20ECDSA%2DSD%20disclosure%20proof%20header%20bytes%200xd9%2C%200x5d%2C%20and%200x01%2C%20an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.';
-            this.test.cell.skipMessage = 'Not Implemented';
-            this.skip();
-            /*
             await assertions.verificationFail({
               verifier,
               credential: fixtures.get('invalidDisclosureProofHeader'),
               reason: 'Should not verify VC with invalid disclosure proof ' +
               'header'
             });
-            */
           });
           it('If the result is not an array of the following five elements ' +
           '— a byte array of length 64; a byte array of length 36; an array ' +
@@ -341,5 +332,9 @@ async function _setup({
   nonbase64ProofValue.proof.proofValue =
     nonbase64ProofValue.proof.proofValue.substring(1);
   credentials.set('invalidProofValuePrefix', nonbase64ProofValue);
+  const invalidProofValueHeader = structuredClone(securedCredential);
+  const disclosureBytes = getBs64UrlBytes(
+    invalidProofValueHeader?.proof?.proofValue);
+  credentials.set('invalidDisclosureProofHeader', null);
   return credentials;
 }


### PR DESCRIPTION
Adds 3 proofValue related tests:

1. "If the proofValue string does not start with u, indicating that it is a multibase-base64url-no-pad-encoded value, an error MUST be raised and SHOULD convey an error type of PROOF_VERIFICATION_ERROR"

```js
  "proof": {
    "type": "DataIntegrityProof",
    "created": "2024-11-17T15:51:32Z",
    "verificationMethod": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP#zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
    "cryptosuite": "ecdsa-sd-2023",
    "proofPurpose": "assertionMethod",
    "proofValue": "2V0BhVhANk3uoC2QPhe9knhEUtqpGS9cdbp1oRKf3SZ9v1iUO-UKS-hFqgacRYOrCSh8duVDK_zY5N5Hndkq8l7VRVAMNFgjgCQDR-DKGWfNv3Kq9TKO1wKXsgvmVlsjqhTWw4U8N-zL23yHWEAjupTpyzvis37wkzIwiXKuizfcF9VvpZfMx7uF2tVW3Al-BbTXQy_HO-EOM3WdH_sZO7K0CP_8fgGMk3UwsmrzWEDBizvJxii_nXROPhqvulJp1e27ZmixVmPUm9ZMT-zl-WAoocGzZnLfwdP_ujRfZVSs_CSJRnz87cqKtgRxG0HqWEBTp4qhxcXJbNVup9iCZAlHLt5oKEYNDEn2KWFMeUqBtwFAWjbVDOQQbPiiZ8XN6Ko8sD0MsSmQ28YkyQD9sir5WEA00uDbdz-gaeeQwPMm4gO-eLWSoIx9LRGLK8F5QEJGa4amwfn8eJ178DUCpr1BRZoGiJAkVR8AzE1Xk8vuXF-JWEAgknRMffrzujB2IW79_1O0SnQf9NyOzPpsws5dbhD8l5PsrzQI6HFaZrhSNayha0ppCw50UdtMo2zSRXWYoVMRWECaWckwEmY6BgddbWySxeYgUwHB3p72kxQ7Eg-9Idd5Z9fEcj8tFwCFDjZJJdXKhBSM71J8dAf9HVZo12Wm51_CWECmmVvtaKWgUlvRoPN6G6wfV25e4fPeo4d8l1ApSllxZ19Ls7-uCRl2jE28NbrCvzmPfg3mLbQBRhM3fabvdcbhoQBYIKzZT5KJrjiCO1Dhv0Ww6rqGS8K_yY56UpQc9j12-oHohAECBAU"
  }
```
2. The base proof assertion: "If the decodedProofValue does not start with the ECDSA-SD base proof header bytes 0xd9, 0x5d, and 0x00, an error MUST be raised and SHOULD convey an error type of PROOF_VERIFICATION_ERROR." Is tested by examing the base proof from the issuer. As base proofs are not designed to pass verification the statement from the spec might be incorrect.

3. "If the decodedProofValue does not start with the ECDSA-SD disclosure proof header bytes 0xd9, 0x5d, and 0x01, an error MUST be raised and SHOULD convey an error type of PROOF_VERIFICATION_ERROR." 

The invalid disclosure proof header bytes are `[0xA1, 0x44, 0x01]` and replace the original proof value header bytes. The actual proofValue is left as is and the invalid header bytes are encoded as a base64 url with the prefix `u`.

Additionally:

- DRYs up an assertion on base proof proofValues into a single assertion
- Changes several async function related to decoding bs58 and bs64 strings into non-async functions
- Changes relevant helpers and assertions into non-async functions if the function only depended on a bs decode function previously.