### PR TITLE
Add ecdsa-sd-2023 proofValue payload missing elements negative test (E -> D)

### DIFF
--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -12,6 +12,10 @@ import {
   encodeBs64Url,
   getBs64UrlBytes
 } from '../helpers.js';
+import {
+  parseDisclosureProofValue,
+  serializeProofValue
+} from './stubs.js';
 import {expect} from 'chai';
 import {getMultiKey} from '../vc-generator/key-gen.js';
 import {getSuites} from './helpers.js';
@@ -355,5 +359,10 @@ async function _setup({
   invalidProofValueHeader.proof.proofValue = `u${encodeBs64Url(invalidBuffer)}`;
   credentials.set('invalidDisclosureProofHeader', invalidProofValueHeader);
   const invalidProofArray = structuredClone(securedCredential);
+  const params = parseDisclosureProofValue({proof: invalidProofArray.proof});
+  invalidProofArray.proof.proofValue = serializeProofValue({
+    payload: [params.baseSignature, params.publicKey]
+  });
+  credentials.set('invalidProofArray', invalidProofArray);
   return credentials;
 }

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -179,8 +179,11 @@ export function sd2023Algorithms({
           'MUST be raised and SHOULD convey an error type of ' +
           'PROOF_VERIFICATION_ERROR.', async function() {
             this.test.link = 'https://w3c.github.io/vc-di-ecdsa/#selective-disclosure-functions:~:text=array%20of%20integers%20%E2%80%94-,an%20error%20MUST%20be%20raised%20and%20SHOULD%20convey%20an%20error%20type%20of%20PROOF_VERIFICATION_ERROR.,-Replace%20the%20fourth';
-            this.test.cell.skipMessage = 'Not Implemented';
-            this.skip();
+            await assertions.verificationFail({
+              verifier,
+              credential: fixtures.get(keyType).get('invalidProofArray'),
+              reason: 'Should not verify proofValue array missing elements'
+            });
           });
           it('The transformation options MUST contain a type identifier for ' +
           'the cryptographic suite (type), a cryptosuite identifier ' +
@@ -351,5 +354,6 @@ async function _setup({
   // invalid 3 byte header
   invalidProofValueHeader.proof.proofValue = `u${encodeBs64Url(invalidBuffer)}`;
   credentials.set('invalidDisclosureProofHeader', invalidProofValueHeader);
+  const invalidProofArray = structuredClone(securedCredential);
   return credentials;
 }

--- a/tests/suites/algorithms-sd.js
+++ b/tests/suites/algorithms-sd.js
@@ -359,7 +359,9 @@ async function _setup({
   invalidProofValueHeader.proof.proofValue = `u${encodeBs64Url(invalidBuffer)}`;
   credentials.set('invalidDisclosureProofHeader', invalidProofValueHeader);
   const invalidProofArray = structuredClone(securedCredential);
+  // parse the existing disclosure proofValue
   const params = parseDisclosureProofValue({proof: invalidProofArray.proof});
+  // create a new proofValue missing 3 elements
   invalidProofArray.proof.proofValue = serializeProofValue({
     payload: [params.baseSignature, params.publicKey]
   });

--- a/tests/suites/proxies.js
+++ b/tests/suites/proxies.js
@@ -2,8 +2,9 @@
  * Copyright 2024 Digital Bazaar, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  */
+import {Token, Type} from 'cborg';
 import crypto from 'node:crypto';
-import {stubDerive} from './stubs.js';
+import {DeriveStub} from './stubs.js';
 /**
  * Creates a proxy of an object with stubs.
  *
@@ -154,7 +155,17 @@ async function _canonizeProof(proof, {
 }
 
 export function invalidCborTagProxy(suite) {
-  const stubs = {derive: stubDerive};
+  const typeEncoders = {
+    Uint8Array(uint8Array) {
+      return [
+        new Token(Type.tag, 2),
+        new Token(Type.bytes, uint8Array.map(b => b + 1))
+      ];
+    }
+  };
+  const stubs = {derive({...args}) {
+    return new DeriveStub({typeEncoders}).derive({...args});
+  }};
   if(suite._cryptosuite) {
     suite._cryptosuite = createProxy({
       original: suite._cryptosuite,

--- a/tests/suites/stubs.js
+++ b/tests/suites/stubs.js
@@ -52,30 +52,6 @@ export class DeriveStub {
     return revealDoc;
   }
 }
-// Stubs the ecdsa-sd-2023 derive function
-export async function stubDerive({
-  cryptosuite, document, proofSet,
-  documentLoader, dataIntegrityProof
-}) {
-  // find matching base `proof` in `proofSet`
-  const {options: {proofId}} = cryptosuite;
-  const baseProof = await _findProof({proofId, proofSet, dataIntegrityProof});
-  // generate data for disclosure
-  const {
-    baseSignature, publicKey, signatures, labelMap, mandatoryIndexes, revealDoc
-  } = await _createDisclosureData(
-    {cryptosuite, document, proof: baseProof, documentLoader});
-
-  // create new disclosure proof
-  const newProof = {...baseProof};
-  newProof.proofValue = await serializeDisclosureProofValue(
-    {baseSignature, publicKey, signatures, labelMap, mandatoryIndexes});
-
-  // attach proof to reveal doc w/o context
-  delete newProof['@context'];
-  revealDoc.proof = newProof;
-  return revealDoc;
-}
 
 // ecdsa-sd-2023 method that uses invalid cbor tags
 function serializeDisclosureProofValue({
@@ -95,10 +71,11 @@ function serializeDisclosureProofValue({
     // array of numbers
     mandatoryIndexes
   ];
-  const cbor = _concatBuffers([
-    CBOR_PREFIX_DERIVED, cborg.encode(payload, {useMaps: true, typeEncoders})
-  ]);
-  return `u${base64url.encode(cbor)}`;
+  return serializeProofValue({
+    prefix: CBOR_PREFIX_DERIVED,
+    payload,
+    typeEncoders
+  });
 }
 
 // ecdsa-sd-2023 test data creation function

--- a/tests/suites/stubs.js
+++ b/tests/suites/stubs.js
@@ -101,6 +101,18 @@ function serializeDisclosureProofValue({
   return `u${base64url.encode(cbor)}`;
 }
 
+// ecdsa-sd-2023 test data creation function
+export function serializeProofValue({
+  prefix = CBOR_PREFIX_DERIVED,
+  payload,
+  typeEncoders
+}) {
+  const cbor = _concatBuffers([
+    prefix, cborg.encode(payload, {useMaps: true, typeEncoders})
+  ]);
+  return `u${base64url.encode(cbor)}`;
+}
+
 // ecdsa-sd-2023 derive helper
 async function _createDisclosureData({
   cryptosuite, document, proof, documentLoader


### PR DESCRIPTION
Adds a single test for the statement: "If the result is not an array of the following five elements — a byte array of length 64; a byte array of length 36; an array of byte arrays, each of length 64; a map of integers to byte arrays, each of length 32; and an array of integers — an error  MUST be raised and SHOULD convey an error type of  PROOF_VERIFICATION_ERROR."

Produces an invalid proofValue with only 2 elements in the payload:

```Js
  invalidProofArray.proof.proofValue = serializeProofValue({
    payload: [params.baseSignature, params.publicKey]
  }); 
```

```js
{
  "@context": [
    "https://www.w3.org/ns/credentials/v2",
    {
      "@protected": true,
      "DriverLicenseCredential": "urn:example:DriverLicenseCredential",
      "DriverLicense": {
        "@id": "urn:example:DriverLicense",
        "@context": {
          "@protected": true,
          "id": "@id",
          "type": "@type",
          "documentIdentifier": "urn:example:documentIdentifier",
          "dateOfBirth": "urn:example:dateOfBirth",
          "expirationDate": "urn:example:expiration",
          "issuingAuthority": "urn:example:issuingAuthority"
        }
      },
      "driverLicense": {
        "@id": "urn:example:driverLicense",
        "@type": "@id"
      }
    }
  ],
  "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
  "type": [
    "VerifiableCredential",
    "DriverLicenseCredential"
  ],
  "issuer": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
  "credentialSubject": {
    "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
    "driverLicense": {
      "type": "DriverLicense",
      "documentIdentifier": "T21387yc328c7y32h23f23",
      "dateOfBirth": "01-01-1990",
      "expirationDate": "01-01-2030",
      "issuingAuthority": "VA"
    }
  },
  "proof": {
    "type": "DataIntegrityProof",
    "created": "2024-11-18T14:52:03Z",
    "verificationMethod": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP#zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
    "cryptosuite": "ecdsa-sd-2023",
    "proofPurpose": "assertionMethod",
    "proofValue": "u2V0BglhAAf1-kHEjD-dONViF43NlXCJHcL4gMc-oiiYgWWG8sFAIpMzYLKzKgsCuGdGAAfsM5KN9L1p05fEjx_v7dVUnQFgjgCQDrcrw3ORQLG2yA2W6Kd4DxhrT5zCivAGyIgja4OxI5N4"
  }
}
```

Additionally:

1. Refactors stubDerive into a class `DeriveStub` which allows serializeDisclosureProofValue to produce both valid and invalid proofValues.
2. Copies `parareDisclosureProofValue` from `ecdsa-sd-2023` into stubs and uses it to produce an invalid fixture.